### PR TITLE
DM Entry Controller

### DIFF
--- a/app/Http/Controllers/DMEntryController.php
+++ b/app/Http/Controllers/DMEntryController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\EntryStoreRequest;
+use App\Models\Entry;
+use Illuminate\Http\Request;
+
+class DMEntryController extends Controller
+{
+    public function index(Request $request)
+    {
+        $entries = DB::table('entries')
+            ->where('type', Entry::TYPE_DM)
+            ->get();
+
+        return view('entry.index', compact('entries'));
+    }
+}

--- a/app/Http/Controllers/DMEntryController.php
+++ b/app/Http/Controllers/DMEntryController.php
@@ -14,9 +14,7 @@ class DMEntryController extends Controller
      */
     public function index(Request $request)
     {
-        $entries = DB::table('entries')
-            ->where('type', Entry::TYPE_DM)
-            ->get();
+        $entries = Entry::where('type', Entry::TYPE_DM)->get();
 
         return view('entry.index', compact('entries'));
     }

--- a/app/Http/Controllers/DMEntryController.php
+++ b/app/Http/Controllers/DMEntryController.php
@@ -16,6 +16,8 @@ class DMEntryController extends Controller
     {
         $entries = Entry::where('type', Entry::TYPE_DM)->get();
 
+        // this should maybe have its own view..
+        // potential fix in the future
         return view('entry.index', compact('entries'));
     }
 }

--- a/app/Http/Controllers/DMEntryController.php
+++ b/app/Http/Controllers/DMEntryController.php
@@ -8,6 +8,10 @@ use Illuminate\Http\Request;
 
 class DMEntryController extends Controller
 {
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
     public function index(Request $request)
     {
         $entries = DB::table('entries')

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -39,6 +39,10 @@ class EntryController extends Controller
 
         $request->session()->flash('entry.id', $entry->id);
 
+        if ($request->type == Entry::TYPE_DM) {
+            return redirect()->route('dm-entry.index');
+        }
+
         return redirect()->route('entry.index');
     }
 

--- a/app/Http/Requests/EntryStoreRequest.php
+++ b/app/Http/Requests/EntryStoreRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Models\Character;
+use App\Models\Entry;
 use Illuminate\Foundation\Http\FormRequest;
 
 class EntryStoreRequest extends FormRequest
@@ -14,6 +15,9 @@ class EntryStoreRequest extends FormRequest
      */
     public function authorize()
     {
+        if (is_null($this->character_id)) {
+            return $this->type == Entry::TYPE_DM;
+        }
         $character = Character::findOrFail($this->character_id);
         return $this->user()->can('update', $character);
     }
@@ -29,7 +33,7 @@ class EntryStoreRequest extends FormRequest
             'user_id' => ['required', 'integer', 'exists:users,id'],
             'adventure_id' => ['required', 'integer', 'exists:adventures,id'],
             'campaign_id' => ['sometimes', 'integer', 'exists:campaigns,id'],
-            'character_id' => ['required', 'integer', 'exists:characters,id'],
+            'character_id' => ['sometimes', 'integer', 'exists:characters,id'],
             'event_id' => ['sometimes', 'integer', 'exists:events,id'],
             'dungeon_master_id' => ['sometimes', 'integer', 'exists:users,id'],
             'dungeon_master' => ['sometimes', 'string'],

--- a/app/Http/Requests/EntryUpdateRequest.php
+++ b/app/Http/Requests/EntryUpdateRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Entry;
 use Illuminate\Foundation\Http\FormRequest;
 
 class EntryUpdateRequest extends FormRequest
@@ -13,6 +14,9 @@ class EntryUpdateRequest extends FormRequest
      */
     public function authorize()
     {
+        if (is_null($this->character_id)) {
+            return $this->type == Entry::TYPE_DM;
+        }
         return $this->user()->can('update', $this->entry->character)  && $this->user()->can('update', $this->entry);
     }
 
@@ -26,7 +30,7 @@ class EntryUpdateRequest extends FormRequest
         return [
             'adventure_id' => ['required', 'integer', 'exists:adventures,id'],
             'campaign_id' => ['sometimes', 'integer', 'exists:campaigns,id'],
-            'character_id' => ['required', 'integer', 'exists:characters,id'],
+            'character_id' => ['sometimes', 'integer', 'exists:characters,id'],
             'event_id' => ['sometimes', 'integer', 'exists:events,id'],
             'dungeon_master_id' => ['sometimes', 'integer', 'exists:users,id'],
             'dungeon_master' => ['sometimes', 'string'],

--- a/app/Observers/EntryObserver.php
+++ b/app/Observers/EntryObserver.php
@@ -14,10 +14,12 @@ class EntryObserver
      */
     public function created(Entry $entry)
     {
-        $character = $entry->character;
-        $character->level += $entry->levels;
+        if ($entry->type != Entry::TYPE_DM) {
+            $character = $entry->character;
+            $character->level += $entry->levels;
 
-        $character->save();
+            $character->save();
+        }
     }
 
     /**
@@ -28,11 +30,13 @@ class EntryObserver
      */
     public function updated(Entry $entry)
     {
-        $character = $entry->character;
-        if ($entry->isDirty('levels')) {
-            $levelDelta = $entry->levels - $entry->getOriginal('levels');
-            $character->level += $levelDelta;
-            $character->save();
+        if ($entry->type != Entry::TYPE_DM) {
+            $character = $entry->character;
+            if ($entry->isDirty('levels')) {
+                $levelDelta = $entry->levels - $entry->getOriginal('levels');
+                $character->level += $levelDelta;
+                $character->save();
+            }
         }
     }
 
@@ -44,10 +48,12 @@ class EntryObserver
      */
     public function deleting(Entry $entry)
     {
-        $character = $entry->character;
-        if ($entry->levels) {
-            $character->level -= $entry->levels;
-            $character->save();
+        if ($entry->type != Entry::TYPE_DM) {
+            $character = $entry->character;
+            if ($entry->levels) {
+                $character->level -= $entry->levels;
+                $character->save();
+            }
         }
     }
 }

--- a/app/Observers/EntryObserver.php
+++ b/app/Observers/EntryObserver.php
@@ -35,6 +35,11 @@ class EntryObserver
                 $levelDelta = $entry->levels - $entry->getOriginal('levels');
                 $character->level += $levelDelta;
                 $character->save();
+            } elseif ($entry->isDirty('character_id')) {
+                $character->level = (is_null($character->level))
+                    ? $entry->levels
+                    : $character->level + $entry->levels;
+                $character->save();
             }
         }
     }

--- a/app/Observers/EntryObserver.php
+++ b/app/Observers/EntryObserver.php
@@ -14,10 +14,9 @@ class EntryObserver
      */
     public function created(Entry $entry)
     {
-        if ($entry->type != Entry::TYPE_DM) {
+        if ($entry->type != Entry::TYPE_DM || !is_null($entry->character)) {
             $character = $entry->character;
             $character->level += $entry->levels;
-
             $character->save();
         }
     }
@@ -30,7 +29,7 @@ class EntryObserver
      */
     public function updated(Entry $entry)
     {
-        if ($entry->type != Entry::TYPE_DM) {
+        if ($entry->type != Entry::TYPE_DM || !is_null($entry->character)) {
             $character = $entry->character;
             if ($entry->isDirty('levels')) {
                 $levelDelta = $entry->levels - $entry->getOriginal('levels');
@@ -48,7 +47,7 @@ class EntryObserver
      */
     public function deleting(Entry $entry)
     {
-        if ($entry->type != Entry::TYPE_DM) {
+        if ($entry->type != Entry::TYPE_DM || !is_null($entry->character)) {
             $character = $entry->character;
             if ($entry->levels) {
                 $character->level -= $entry->levels;

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,9 @@ Route::resource('beyond-import', App\Http\Controllers\BeyondImportController::cl
 Route::resource('adventures-league-import', App\Http\Controllers\AdventuresLeagueImportController::class)
     ->only(['index', 'store']);
 
+Route::resource('dm-entry', \App\Http\Controllers\DMEntryController::class)
+    ->only('index');
+
 if (config('app.env') !== 'production') {
     Route::get('/token', fn () => csrf_token());
     Route::get('/dev/{path}', fn ($path) => Inertia::render(Str::of($path)->replace('/', ' ')->title()->replace(' ', '/')))

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,16 +60,18 @@ Route::middleware(['auth', 'throttle'])->group(function () {
     Route::resource('role', App\Http\Controllers\RoleController::class);
 
     Route::resource('campaign', App\Http\Controllers\CampaignController::class);
+
+    Route::resource('beyond-import', App\Http\Controllers\BeyondImportController::class)
+        ->only('store');
+
+    Route::resource('adventures-league-import', App\Http\Controllers\AdventuresLeagueImportController::class)
+        ->only(['index', 'store']);
+
+    Route::resource('dm-entry', \App\Http\Controllers\DMEntryController::class)
+        ->only('index');
 });
 
-Route::resource('beyond-import', App\Http\Controllers\BeyondImportController::class)
-    ->only('store');
 
-Route::resource('adventures-league-import', App\Http\Controllers\AdventuresLeagueImportController::class)
-    ->only(['index', 'store']);
-
-Route::resource('dm-entry', \App\Http\Controllers\DMEntryController::class)
-    ->only('index');
 
 if (config('app.env') !== 'production') {
     Route::get('/token', fn () => csrf_token());

--- a/tests/Feature/Http/Controllers/DMEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/DMEntryControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Http\Controllers;
+
+use App\Http\Controllers\DMEntryController;
+use App\Models\Adventure;
+use App\Models\Campaign;
+use App\Models\Character;
+use App\Models\Entry;
+use App\Models\Event;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Auth;
+use JMac\Testing\Traits\AdditionalAssertions;
+use Tests\TestCase;
+
+class DMEntryControllerTest extends TestCase
+{
+    use AdditionalAssertions;
+    use RefreshDatabase;
+    use WithFaker;
+
+    public $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        Auth::login($this->user);
+    }
+
+    /**
+     * @test
+     */
+    public function index_displays_view()
+    {
+        $entry = Entry::factory(2)->create([
+            'type' => Entry::TYPE_DM,
+        ]);
+
+        $response = $this->get(route('dm-entry.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('entry.index');
+        $response->assertViewHas('entries');
+
+        $responseEntries = $response->viewData('entries');
+
+        foreach ($responseEntries as $responseEntry) {
+            $this->assertEquals(Entry::TYPE_DM, $responseEntry->type);
+        }
+
+        $this->assertTrue($responseEntries->count() >= 2);
+    }
+}

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -324,7 +324,7 @@ class EntryControllerTest extends TestCase
     public function update_dm_entry_on_character_updates_level()
     {
         $character = Character::factory()->create([
-            'level' => 3,
+            'level' => 0,
         ]);
 
         $entry = Entry::factory()->create([

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -274,6 +274,98 @@ class EntryControllerTest extends TestCase
         $this->assertEquals($gp, $entry->gp);
     }
 
+    /**
+     * @test
+     */
+    public function store_dm_entry_on_character_updates_level()
+    {
+        $character = Character::factory()->create([
+            'level' => 1,
+        ]);
+
+        $character->user()->associate($this->user)->save();
+
+        $oldLevel = $character->level;
+
+        $adventure = Adventure::factory()->create();
+        $campaign = Campaign::factory()->create();
+        $event = Event::factory()->create();
+        $dungeon_master_user = User::factory()->create();
+        $dungeon_master = $this->faker->word;
+        $date_played = $this->faker->dateTime();
+        $location = $this->faker->word;
+        $type = Entry::TYPE_DM;
+        $levels = 5;
+        $gp = $this->faker->randomFloat(2, 0, 9999999.99);
+
+        $response = $this->actingAs($this->user)->post(route('entry.store'), [
+            'user_id' => $this->user->id,
+            'adventure_id' => $adventure->id,
+            'campaign_id' => $campaign->id,
+            'character_id' => $character->id,
+            'event_id' => $event->id,
+            'dungeon_master_id' => $dungeon_master_user->id,
+            'dungeon_master' => $dungeon_master,
+            'date_played' => $date_played,
+            'location' => $location,
+            'type' => $type,
+            'levels' => $levels,
+            'gp' => $gp,
+        ]);
+
+        $character->refresh();
+
+        $this->assertEquals($oldLevel + $levels, $character->level);
+    }
+
+    /**
+     * @test
+     */
+    public function update_dm_entry_on_character_updates_level()
+    {
+        $character = Character::factory()->create([
+            'level' => 3,
+        ]);
+
+        $entry = Entry::factory()->create([
+            'type' => Entry::TYPE_DM,
+            'levels' => 3,
+        ]);
+
+        $character->user()->associate($this->user)->save();
+        $entry->character()->associate($character)->save();
+
+        $oldLevel = $character->level;
+
+        $adventure = Adventure::factory()->create();
+        $campaign = Campaign::factory()->create();
+        $event = Event::factory()->create();
+        $dungeon_master_user = User::factory()->create();
+        $dungeon_master = $this->faker->word;
+        $date_played = $this->faker->dateTime();
+        $location = $this->faker->word;
+        $type = Entry::TYPE_DM;
+        $levels = 5;
+        $gp = $this->faker->randomFloat(2, 0, 9999999.99);
+
+        $response = $this->actingAs($this->user)->put(route('entry.update', $entry), [
+            'adventure_id' => $adventure->id,
+            'campaign_id' => $campaign->id,
+            'event_id' => $event->id,
+            'dungeon_master_id' => $dungeon_master_user->id,
+            'dungeon_master' => $dungeon_master,
+            'date_played' => $date_played,
+            'location' => $location,
+            'type' => $type,
+            'levels' => $levels,
+            'gp' => $gp,
+        ]);
+
+        $character->refresh();
+
+        $this->assertEquals(5, $character->level);
+    }
+
 
     /**
      * @test

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -366,6 +366,31 @@ class EntryControllerTest extends TestCase
         $this->assertEquals(5, $character->level);
     }
 
+    /**
+     * @test
+     */
+    public function update_entry_with_character_updates_level()
+    {
+        $character = Character::factory()->create([
+            'level' => 1,
+            ]);
+
+        $entry = Entry::factory()->create([
+            'character_id' => null,
+            'type' => Entry::TYPE_DM,
+            'levels' => 3,
+        ]);
+
+        $character->user()->associate($this->user)->save();
+        $entry->character()->associate($character)->save();
+
+
+        $oldLevel = $character->level;
+
+        $character->refresh();
+
+        $this->assertEquals($entry->level + $oldLevel, $character->level);
+    }
 
     /**
      * @test

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -230,6 +230,21 @@ class EntryControllerTest extends TestCase
         $response = $this->actingAs($this->user)->put(route('entry.update', $entry), [
             'adventure_id' => $adventure->id,
             'campaign_id' => $campaign->id,
+            'event_id' => $event->id,
+            'dungeon_master_id' => $dungeon_master_user->id,
+            'dungeon_master' => $dungeon_master,
+            'date_played' => $date_played,
+            'location' => $location,
+            'type' => $type,
+            'levels' => $levels,
+            'gp' => $gp,
+        ]);
+
+        $response->assertForbidden();
+
+        $response = $this->actingAs($this->user)->put(route('entry.update', $entry), [
+            'adventure_id' => $adventure->id,
+            'campaign_id' => $campaign->id,
             'character_id' => $character->id,
             'event_id' => $event->id,
             'dungeon_master_id' => $dungeon_master_user->id,


### PR DESCRIPTION
## Description
Closes #117
- Creates a controller to handle specific behaviour of DM entries which do not belong to a character.
- Upon /entry.store , if type is 'dm' the response will be a redirect to the index of DMEntryController.
- A new view may be needed to be added in the future in case we wish to differentiate listing characterless DM entries from a list of entries on a character.
- Also fixes an issue in web.php routes where some routes did not have middleware.