### PR TITLE
118 Attach DM Entries to a Character

### DIFF
--- a/app/Http/Controllers/CharacterBulkAttachDMEntryController.php
+++ b/app/Http/Controllers/CharacterBulkAttachDMEntryController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\AttachDMEntryRequest;
+use App\Models\Character;
+use App\Models\Entry;
+
+class CharacterBulkAttachDMEntryController extends Controller
+{
+    /**
+     * @param \App\Http\Requests\AttachDMEntryRequestController $request
+     * @param \App\Models\Character $character
+     * @return \Illuminate\Http\Response
+     */
+    public function update(AttachDMEntryRequest $request, Character $character)
+    {
+        $validated = $request->validated();
+        $entries = Entry::findOrFail($validated['dm_entry_ids']);
+        $character->entries()->saveMany($entries);
+
+        return redirect()->route('dm-entry.index');
+    }
+}

--- a/app/Http/Controllers/CharacterBulkAttachDMEntryController.php
+++ b/app/Http/Controllers/CharacterBulkAttachDMEntryController.php
@@ -9,7 +9,7 @@ use App\Models\Entry;
 class CharacterBulkAttachDMEntryController extends Controller
 {
     /**
-     * @param \App\Http\Requests\AttachDMEntryRequestController $request
+     * @param \App\Http\Requests\AttachDMEntryRequest $request
      * @param \App\Models\Character $character
      * @return \Illuminate\Http\Response
      */

--- a/app/Http/Requests/AttachDMEntryRequest.php
+++ b/app/Http/Requests/AttachDMEntryRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttachDMEntryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user()->can('update', $this->character);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'dm_entry_ids' => ['required', 'array'],
+            'dm_entry_ids.*' => ['required', 'integer', 'distinct:strict', 'exists:entries,id']
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,6 +72,10 @@ Route::middleware(['auth', 'throttle'])->group(function () {
 
     Route::resource('dm-entry', \App\Http\Controllers\DMEntryController::class)
         ->only('index');
+
+    Route::resource('attach-entry-to-character', App\Http\Controllers\CharacterBulkAttachDMEntryController::class)->parameters([
+        'attach-entry-to-character' => 'character'
+        ])->only('update');
 });
 
 


### PR DESCRIPTION
## Description
Closes #118
Adds a controller endpoint that accepts an array of entry ids and attaches them to a character belonging to the user.

## How to Test
- Create a character.
- Create a few DM Entries with no `character_id` and note their levels.
- Send a `PUT` request to the `attach-entry-to-character.update` route by passing a character and an array containing the newly created DM Entries.
- Observe the observer adding the levels gained from the DM Entries to the character.

