### PR TITLE
Add cypress test for character log migrator story

### DIFF
--- a/cypress/integration/character_exploration.js
+++ b/cypress/integration/character_exploration.js
@@ -75,14 +75,6 @@ describe('Character Management Test Suite', () => {
 
     it('Explore Private Character', () => {
         cy.login({name: characterExplorer})
-        cy.intercept(
-            'GET',
-            Cypress.Laravel.route('character.show').replace(
-                '{character}',
-                character_exploration_id,
-            ),
-            {statusCode: 403},
-        ).as('getPrivateCharacter')
         cy.request({
             method: 'GET',
             url: Cypress.Laravel.route('character.show').replace(

--- a/cypress/integration/character_log_migrator.js
+++ b/cypress/integration/character_log_migrator.js
@@ -1,0 +1,23 @@
+describe('Character Management Test Suite', () => {
+    const testusername = 'testuser'
+    const ALCharacterName = 'Grod'
+    const csvPath = '../../database/mocks/grod.csv'
+
+    before(() => {
+        cy.refreshDatabase()
+    })
+
+    beforeEach(() => {
+        cy.login({name: testusername})
+        cy.intercept('GET', Cypress.Laravel.route('character.index')).as('character')
+        cy.visit(Cypress.Laravel.route('character.index'))
+        cy.wait('@character')
+        cy.contains('button', 'Import').click()
+    })
+
+    it('AdventurersLeagueLog Import', () => {
+        cy.get('#ALimport').attachFile({filePath: csvPath, allowEmpty: false})
+        cy.contains('button', 'Import').click()
+        cy.contains(ALCharacterName)
+    })
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -17,6 +17,7 @@ import './commands'
 import './laravel-commands'
 import './laravel-routes'
 import './assertions'
+import 'cypress-file-upload'
 
 before(() => {
     // cy.task('activateCypressEnvFile', {}, {log: false})

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "babel-loader": "^8.2.2",
         "babel-plugin-import": "^1.13.3",
         "cypress": "^8.7.0",
+        "cypress-file-upload": "^5.0.8",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-cypress": "^2.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,6 +3825,11 @@ csstype@^3.0.2, csstype@^3.0.9:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
   integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
 
+cypress-file-upload@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
+  integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
+
 cypress@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.7.0.tgz#2ee371f383d8f233d3425b6cc26ddeec2668b6da"


### PR DESCRIPTION
## Description
Closes #169
Write E2E Cypress tests for Character Exploration #35 user story acceptance criteria.

## Acceptance Criteria
- Upload a csv from AdventurersLeagueLog

## Out of Scope
Since the D&D Beyond import feature requires using their platform, making an end-to-end test would be unsafe since the pipeline would depend on their website being up.