### PR TITLE
Add item creation when storing Entries

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
-."$(dirname "$0")/_/husky.sh"
+./"$(dirname "$0")/_/husky.sh"
 
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
-."$(dirname "$0")/_/husky.sh"
+./"$(dirname "$0")/_/husky.sh"
 
 npx lint-staged

--- a/app/Actions/CreateEntryItems.php
+++ b/app/Actions/CreateEntryItems.php
@@ -19,8 +19,9 @@ class CreateEntryItems
      */
     public function handle(Entry $entry, array $items)
     {
+        $out = collect();
         foreach ($items as $item) {
-            Item::create(
+            $out[] = Item::create(
                 array_merge([
                     'author_id' => Auth::id(),
                     'entry_id' => $entry->id,
@@ -28,5 +29,7 @@ class CreateEntryItems
                 ], $item)
             );
         }
+
+        return $out;
     }
 }

--- a/app/Actions/CreateEntryItems.php
+++ b/app/Actions/CreateEntryItems.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Entry;
+use App\Models\Item;
+use Illuminate\Support\Facades\Auth;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class CreateEntryItems
+{
+    use AsAction;
+
+    /**
+     * Expect an array of item details, create each item and attach them to the appropriate relation objects
+     *
+     * @param Entry $entry
+     * @param array $items
+     */
+    public function handle(Entry $entry, array $items)
+    {
+        foreach ($items as $item) {
+            Item::create(
+                array_merge([
+                    'author_id' => Auth::id(),
+                    'entry_id' => $entry->id,
+                    'character_id' => $entry->character_id
+                ], $item)
+            );
+        }
+    }
+}

--- a/app/Actions/CreateEntryItems.php
+++ b/app/Actions/CreateEntryItems.php
@@ -20,16 +20,21 @@ class CreateEntryItems
     public function handle(Entry $entry, array $items)
     {
         $out = collect();
+
+        if ($entry->items()->count() >= count($items)) {
+            // This is probably a "sync" so clear the existing items
+            $entry->items()->delete();
+        }
+
         foreach ($items as $item) {
-            $out[] = Item::create(
+            $out[] = new Item(
                 array_merge([
                     'author_id' => Auth::id(),
-                    'entry_id' => $entry->id,
                     'character_id' => $entry->character_id
                 ], $item)
             );
         }
 
-        return $out;
+        return $entry->items()->saveMany($out);
     }
 }

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -43,9 +43,9 @@ class EntryController extends Controller
     {
         $entryData = collect($request->validated())->except('items');
         $itemData = collect($request->validated())->only('items');
-        $entry = Entry::create($entryData);
+        $entry = Entry::create($entryData->toArray());
         // attach any associated items to the entry in question.
-        CreateEntryItems::run($entry, $itemData);
+        CreateEntryItems::run($entry, $itemData->toArray());
 
         $request->session()->flash('entry.id', $entry->id);
 

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -37,7 +37,7 @@ class EntryController extends Controller
 
     /**
      * @param \App\Http\Requests\EntryStoreRequest $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function store(EntryStoreRequest $request)
     {
@@ -45,7 +45,7 @@ class EntryController extends Controller
         $itemData = collect($request->validated())->only('items');
         $entry = Entry::create($entryData->toArray());
         // attach any associated items to the entry in question.
-        CreateEntryItems::run($entry, $itemData->toArray());
+        CreateEntryItems::run($entry, $itemData['items']);
 
         $request->session()->flash('entry.id', $entry->id);
 
@@ -53,7 +53,7 @@ class EntryController extends Controller
             return redirect()->route('dm-entry.index');
         }
 
-        return redirect()->route('entry.index');
+        return redirect()->route('character.show', $entry->character_id);
     }
 
     /**

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -45,7 +45,7 @@ class EntryController extends Controller
         $itemData = collect($request->validated())->only('items');
         $entry = Entry::create($entryData->toArray());
         // attach any associated items to the entry in question.
-        CreateEntryItems::run($entry, $itemData['items']);
+        CreateEntryItems::run($entry, $itemData['items'] ?? []);
 
         $request->session()->flash('entry.id', $entry->id);
 

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -99,7 +99,7 @@ class EntryController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Models\Entry $entry
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function destroy(Request $request, Entry $entry)
     {

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\CreateEntryItems;
 use App\Http\Requests\EntryStoreRequest;
 use App\Http\Requests\EntryUpdateRequest;
 use App\Models\Entry;
@@ -40,7 +41,11 @@ class EntryController extends Controller
      */
     public function store(EntryStoreRequest $request)
     {
-        $entry = Entry::create($request->validated());
+        $entryData = collect($request->validated())->except('items');
+        $itemData = collect($request->validated())->only('items');
+        $entry = Entry::create($entryData);
+        // attach any associated items to the entry in question.
+        CreateEntryItems::run($entry, $itemData);
 
         $request->session()->flash('entry.id', $entry->id);
 

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -79,11 +79,14 @@ class EntryController extends Controller
     /**
      * @param \App\Http\Requests\EntryUpdateRequest $request
      * @param \App\Models\Entry $entry
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function update(EntryUpdateRequest $request, Entry $entry)
     {
-        $entry->update($request->validated());
+        $entryData = collect($request->validated())->except('items');
+        $itemData = collect($request->validated())->only('items');
+        $entry->update($entryData->toArray());
+        CreateEntryItems::run($entry, $itemData['items'] ?? []);
         $request->session()->flash('entry.id', $entry->id);
 
         if ($request->type == Entry::TYPE_DM) {

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -77,7 +77,11 @@ class ItemController extends Controller
 
         $request->session()->flash('item.id', $item->id);
 
-        return redirect()->route('item.index');
+        if ($charId = $item->character_id) {
+            return redirect()->route('character.show', $charId);
+        } else {
+            return redirect()->route('dm-entry.index');
+        }
     }
 
     /**
@@ -87,8 +91,13 @@ class ItemController extends Controller
      */
     public function destroy(Request $request, Item $item)
     {
+        $charId = $item->character_id;
         $item->delete();
 
-        return redirect()->route('item.index');
+        if ($charId) {
+            return redirect()->route('character.show', $charId);
+        } else {
+            return redirect()->route('dm-entry.index');
+        }
     }
 }

--- a/app/Http/Requests/EntryStoreRequest.php
+++ b/app/Http/Requests/EntryStoreRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Models\Character;
 use App\Models\Entry;
+use App\Models\Item;
 use Illuminate\Foundation\Http\FormRequest;
 
 class EntryStoreRequest extends FormRequest
@@ -29,6 +30,7 @@ class EntryStoreRequest extends FormRequest
      */
     public function rules()
     {
+        $rarities = implode(",", Item::RARITY);
         return [
             'user_id' => ['required', 'integer', 'exists:users,id'],
             'adventure_id' => ['required', 'integer', 'exists:adventures,id'],
@@ -43,6 +45,9 @@ class EntryStoreRequest extends FormRequest
             'levels' => ['sometimes', 'integer'],
             'gp' => ['sometimes', 'numeric', 'between:-999999999999999999999999999999.99,999999999999999999999999999999.99'],
             'downtime' => ['sometimes', 'integer'],
+            'items' => ['sometimes', 'array'],
+            'items.*.name' => ['string', 'required_with:items'],
+            'items.*.rarity' => ["in:{$rarities}", 'required_with:items']
         ];
     }
 }

--- a/app/Http/Requests/EntryUpdateRequest.php
+++ b/app/Http/Requests/EntryUpdateRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Models\Entry;
+use App\Models\Item;
 use Illuminate\Foundation\Http\FormRequest;
 
 class EntryUpdateRequest extends FormRequest
@@ -27,6 +28,7 @@ class EntryUpdateRequest extends FormRequest
      */
     public function rules()
     {
+        $rarities = implode(",", Item::RARITY);
         return [
             'adventure_id' => ['required', 'integer', 'exists:adventures,id'],
             'campaign_id' => ['sometimes', 'integer', 'exists:campaigns,id'],
@@ -40,6 +42,9 @@ class EntryUpdateRequest extends FormRequest
             'levels' => ['sometimes', 'integer'],
             'gp' => ['sometimes', 'numeric', 'between:-999999999999999999999999999999.99,999999999999999999999999999999.99'],
             'downtime' => ['sometimes', 'integer'],
+            'items' => ['sometimes', 'array'],
+            'items.*.name' => ['string', 'required_with:items'],
+            'items.*.rarity' => ["in:{$rarities}", 'required_with:items']
         ];
     }
 }

--- a/app/Http/Requests/ItemStoreRequest.php
+++ b/app/Http/Requests/ItemStoreRequest.php
@@ -31,7 +31,6 @@ class ItemStoreRequest extends FormRequest
             'rarity' => ['required', 'in:common,uncommon,rare,very_rare,legendary'],
             'tier' => ['required', 'string'],
             'description' => ['required', 'string'],
-            'counted' => ['required', 'string'],
             'author_id' => ['required', 'integer', 'exists:users,id'],
         ];
     }

--- a/app/Http/Requests/ItemUpdateRequest.php
+++ b/app/Http/Requests/ItemUpdateRequest.php
@@ -30,7 +30,6 @@ class ItemUpdateRequest extends FormRequest
             'rarity' => ['required', 'in:common,uncommon,rare,very_rare,legendary'],
             'tier' => ['required', 'string'],
             'description' => ['required', 'string'],
-            'counted' => ['required', 'string'],
             'author_id' => ['required', 'integer', 'exists:users,id'],
         ];
     }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -37,6 +37,8 @@ class Item extends Model
         'author_id' => 'integer',
     ];
 
+    public const RARITY = ["common","uncommon","rare","very_rare","legendary"];
+
 
     public function trades()
     {

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -21,7 +21,6 @@ class Item extends Model
         'rarity',
         'tier',
         'description',
-        'counted',
         'author_id',
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "laravel/framework": "^8.54",
         "laravel/sanctum": "^2.6",
         "laravel/tinker": "^2.5",
+        "lorisleiva/laravel-actions": "^2.1",
         "tightenco/ziggy": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68a42f906cfdbb1abf7f14ac78bed2cb",
+    "content-hash": "24b1eb9b1de4d4db8516f6d9c651bee2",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1731,6 +1731,80 @@
                 }
             ],
             "time": "2021-09-25T08:23:19+00:00"
+        },
+        {
+            "name": "lorisleiva/laravel-actions",
+            "version": "v2.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lorisleiva/laravel-actions.git",
+                "reference": "4df9827a8fc49ba4b0efd98d85c5a43787284b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lorisleiva/laravel-actions/zipball/4df9827a8fc49ba4b0efd98d85c5a43787284b8c",
+                "reference": "4df9827a8fc49ba4b0efd98d85c5a43787284b8c",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.15",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^6.0",
+                "pestphp/pest": "^0.3.14",
+                "phpunit/phpunit": "^9.3.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Lorisleiva\\Actions\\ActionServiceProvider"
+                    ],
+                    "aliases": {
+                        "Action": "Lorisleiva\\Actions\\Facades\\Actions"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lorisleiva\\Actions\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loris Leiva",
+                    "email": "loris.leiva@gmail.com",
+                    "homepage": "https://lorisleiva.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel components that take care of one specific task",
+            "homepage": "https://github.com/lorisleiva/laravel-actions",
+            "keywords": [
+                "action",
+                "command",
+                "component",
+                "controller",
+                "job",
+                "laravel",
+                "object"
+            ],
+            "support": {
+                "issues": "https://github.com/lorisleiva/laravel-actions/issues",
+                "source": "https://github.com/lorisleiva/laravel-actions/tree/v2.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/lorisleiva",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-17T19:15:19+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -32,7 +32,6 @@ class ItemFactory extends Factory
             'rarity' => $this->faker->randomElement(["common","uncommon","rare","very_rare","legendary"]),
             'tier' => $this->faker->word(),
             'description' => $this->faker->text(),
-            'counted' => $this->faker->word(),
             'author_id' => User::factory()
         ];
     }

--- a/database/migrations/2021_09_23_221026_create_items_table.php
+++ b/database/migrations/2021_09_23_221026_create_items_table.php
@@ -19,13 +19,13 @@ class CreateItemsTable extends Migration
             $table->id();
             $table->foreignId('entry_id')->constrained();
             $table->foreignId('character_id')->constrained();
+            $table->foreignId('author_id')->constrained('users', 'id');
             $table->string('name');
             $table->enum('rarity', ["common","uncommon","rare","very_rare","legendary"]);
             $table->string('tier');
             $table->text('description');
             $table->string('counted');
             $table->timestamps();
-            $table->foreignId('author_id')->constrained('users', 'id');
         });
 
         Schema::enableForeignKeyConstraints();

--- a/database/migrations/2021_11_22_201558_add_nullables_to_items_table.php
+++ b/database/migrations/2021_11_22_201558_add_nullables_to_items_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNullablesToItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            Schema::disableForeignKeyConstraints();
+            // not included in scope anymore due to season 11 rules
+            $table->dropColumn('counted');
+
+            $table->text('description')->nullable()->change();
+            $table->string('tier')->nullable()->change();
+            $table->unsignedBigInteger('character_id')->nullable()->change();
+            Schema::enableForeignKeyConstraints();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            Schema::disableForeignKeyConstraints();
+            $table->string('counted');
+            $table->text('description')->change();
+            $table->string('tier')->change();
+            $table->dropForeign(['character_id']);
+            $table->unsignedBigInteger('character_id')->change();
+            Schema::enableForeignKeyConstraints();
+        });
+    }
+}

--- a/tests/Feature/Http/Controllers/ItemControllerTest.php
+++ b/tests/Feature/Http/Controllers/ItemControllerTest.php
@@ -191,7 +191,7 @@ class ItemControllerTest extends TestCase
 
         $item->refresh();
 
-        $response->assertRedirect(route('item.index'));
+        $response->assertRedirect(route('character.show', $character->id));
         $response->assertSessionHas('item.id', $item->id);
 
         $this->assertEquals($entry->id, $item->entry_id);
@@ -210,10 +210,11 @@ class ItemControllerTest extends TestCase
     public function destroy_deletes_and_redirects()
     {
         $item = Item::factory()->create();
+        $characterId = $item->character_id;
 
         $response = $this->delete(route('item.destroy', $item));
 
-        $response->assertRedirect(route('item.index'));
+        $response->assertRedirect(route('character.show', $characterId));
 
         $this->assertDeleted($item);
     }

--- a/tests/Feature/Http/Controllers/ItemControllerTest.php
+++ b/tests/Feature/Http/Controllers/ItemControllerTest.php
@@ -93,7 +93,6 @@ class ItemControllerTest extends TestCase
         $rarity = $this->faker->randomElement(["common","uncommon","rare","very_rare","legendary"]);
         $tier = $this->faker->word;
         $description = $this->faker->text;
-        $counted = $this->faker->word;
         $author = User::factory()->create();
 
         $response = $this->actingAs($character->user)->post(route('item.store'), [
@@ -103,7 +102,6 @@ class ItemControllerTest extends TestCase
             'rarity' => $rarity,
             'tier' => $tier,
             'description' => $description,
-            'counted' => $counted,
             'author_id' => $author->id
         ]);
 
@@ -114,7 +112,6 @@ class ItemControllerTest extends TestCase
             ->where('rarity', $rarity)
             ->where('tier', $tier)
             ->where('description', $description)
-            ->where('counted', $counted)
             ->where('author_id', $author->id)
             ->get();
 
@@ -180,7 +177,6 @@ class ItemControllerTest extends TestCase
         $rarity = $this->faker->randomElement(["common","uncommon","rare","very_rare","legendary"]);
         $tier = $this->faker->word;
         $description = $this->faker->text;
-        $counted = $this->faker->word;
         $author = User::factory()->create();
 
         $response = $this->actingAs($item->user())->put(route('item.update', $item), [
@@ -190,7 +186,6 @@ class ItemControllerTest extends TestCase
             'rarity' => $rarity,
             'tier' => $tier,
             'description' => $description,
-            'counted' => $counted,
             'author_id' => $author->id
         ]);
 
@@ -205,7 +200,6 @@ class ItemControllerTest extends TestCase
         $this->assertEquals($rarity, $item->rarity);
         $this->assertEquals($tier, $item->tier);
         $this->assertEquals($description, $item->description);
-        $this->assertEquals($counted, $item->counted);
         $this->assertEquals($author->id, $item->author_id);
     }
 

--- a/tests/Unit/Actions/CreateEntryItemsTest.php
+++ b/tests/Unit/Actions/CreateEntryItemsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\CreateEntryItems;
+use App\Models\Entry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Auth;
+use JMac\Testing\Traits\AdditionalAssertions;
+use Tests\TestCase;
+
+class CreateEntryItemsTest extends TestCase
+{
+    use AdditionalAssertions;
+    use RefreshDatabase;
+    use WithFaker;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        Auth::login($this->user);
+    }
+
+    /**
+     * @test
+     */
+    public function items_can_be_created_in_bulk()
+    {
+        // Assign
+        $entry = Entry::factory()->create();
+        $itemData = [
+            ['name' => "Longsword +1", 'rarity' => "uncommon"],
+            ['name' => "Amulet of Health", 'rarity' => "rare", 'description' => "Your Constitution score is 19 while you wear this amulet. It has no effect on you if your Constitution is already 19 or higher without it."],
+        ];
+
+        // Act
+        $items = CreateEntryItems::run($entry, $itemData);
+
+        // Assert
+        $this->assertCount(2, $items);
+        $this->assertDatabaseHas('items', $itemData[0]);
+        $this->assertDatabaseHas('items', $itemData[1]);
+    }
+}

--- a/tests/Unit/Actions/CreateEntryItemsTest.php
+++ b/tests/Unit/Actions/CreateEntryItemsTest.php
@@ -43,5 +43,10 @@ class CreateEntryItemsTest extends TestCase
         $this->assertCount(2, $items);
         $this->assertDatabaseHas('items', $itemData[0]);
         $this->assertDatabaseHas('items', $itemData[1]);
+        $this->assertEquals($itemData[0]['name'], $items[0]['name']);
+        $this->assertEquals($itemData[0]['rarity'], $items[0]['rarity']);
+        $this->assertEquals($itemData[1]['name'], $items[1]['name']);
+        $this->assertEquals($itemData[1]['rarity'], $items[1]['rarity']);
+        $this->assertEquals($itemData[1]['description'], $items[1]['description']);
     }
 }


### PR DESCRIPTION
## Description
Closes #183 

Adds the ability to specify and `items` array in the entry form on `EntryController@create()`. The items array should take a the format specified in #183. Each element in this `items` form array is an array with sub arrays. Each of these sub associative sub arrays specify properties of a particular item (These properties are found on the database, or the `$fillable` array on `Item`).

Installs a Laravel Action package, rather than using "handcrafted" actions, this provides a bit more structure and documentation! see [more information here](https://github.com/lorisleiva/laravel-actions).  

## How to Test
We're still faced with the same issue that doesn't allow for directly testing the endpoint due to sanctum + inertia, but you can test the added action instead, which captures most of the functionality of this PR .
1. Start tinker
2. use `Auth::loginUsingId(...)` to auth as some user in your `User` table
3. Create or query for an `Entry` saved to some variable `$e`
3. Call `CreateEntryItems::run($e, [['name' => 'some name...', 'rarity' => 'uncommon'], [...], ...])` fill the second parameter as you please.  
   - _note_: the fields `name`, and `rarity` are required fields, so unless checking error states, make sure to include those
4. Observe that the Entry has your items associated with it.