### PR TITLE
184 dm entry reward

### DIFF
--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\EntryStoreRequest;
 use App\Http\Requests\EntryUpdateRequest;
 use App\Models\Entry;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 
 class EntryController extends Controller
@@ -44,10 +45,19 @@ class EntryController extends Controller
         $entryData = collect($request->validated())->except('items');
         $itemData = collect($request->validated())->only('items');
 
+        if ($itemData->has('items')) {
+            $itemData = $itemData['items'];
+        }
+
+        if ($itemData instanceof Collection) {
+            $itemData = $itemData->toArray();
+        }
+
         //possibly implement as function for reusability
         if ($entryData->get('choice') == 'advancement') {
             // advancement: increment character's level
             $entryData['levels'] = 1;
+            $itemData = [];
         } elseif ($entryData->get('choice') == 'magic_item') {
             // magic_item: attach item to character of choice, and set entry's levels to 0
             $itemData = [$itemData[0] ?? []];
@@ -60,7 +70,7 @@ class EntryController extends Controller
 
         $entry = Entry::create($entryData->toArray());
         // attach any associated items to the entry in question.
-        CreateEntryItems::run($entry, $itemData['items'] ?? []);
+        CreateEntryItems::run($entry, $itemData ?? []);
         $request->session()->flash('entry.id', $entry->id);
 
         if ($request->type == Entry::TYPE_DM) {
@@ -100,10 +110,19 @@ class EntryController extends Controller
         $entryData = collect($request->validated())->except('items');
         $itemData = collect($request->validated())->only('items');
 
+        if ($itemData->has('items')) {
+            $itemData = $itemData['items'];
+        }
+
+        if ($itemData instanceof Collection) {
+            $itemData = $itemData->toArray();
+        }
+
         //replace with function call when implemented
         if ($entryData->get('choice') == 'advancement') {
             // advancement: increment character's level
             $entryData['levels'] = 1;
+            $itemData = [];
         } elseif ($entryData->get('choice') == 'magic_item') {
             // magic_item: attach item to character of choice, and set entry's levels to 0
             $itemData = [$itemData[0] ?? []];
@@ -115,7 +134,7 @@ class EntryController extends Controller
         }
 
         $entry->update($entryData->toArray());
-        CreateEntryItems::run($entry, $itemData['items'] ?? []);
+        CreateEntryItems::run($entry, $itemData ?? []);
         $request->session()->flash('entry.id', $entry->id);
 
         if ($request->type == Entry::TYPE_DM) {

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -43,10 +43,24 @@ class EntryController extends Controller
     {
         $entryData = collect($request->validated())->except('items');
         $itemData = collect($request->validated())->only('items');
+
+        //possibly implement as function for reusability
+        if ($entryData->get('choice') == 'advancement') {
+            // advancement: increment character's level
+            $entryData['levels'] = 1;
+        } elseif ($entryData->get('choice') == 'magic_item') {
+            // magic_item: attach item to character of choice, and set entry's levels to 0
+            $itemData = [$itemData[0] ?? []];
+            $entryData['levels'] = 0;
+        } elseif ($entryData->get('choice') == 'campaign_reward') {
+            // campaign reward: set levels = 0, no item(s), should contain custom note
+            $itemData = [];
+            $entryData['levels'] = 0;
+        }
+
         $entry = Entry::create($entryData->toArray());
         // attach any associated items to the entry in question.
         CreateEntryItems::run($entry, $itemData['items'] ?? []);
-
         $request->session()->flash('entry.id', $entry->id);
 
         if ($request->type == Entry::TYPE_DM) {
@@ -85,6 +99,21 @@ class EntryController extends Controller
     {
         $entryData = collect($request->validated())->except('items');
         $itemData = collect($request->validated())->only('items');
+
+        //replace with function call when implemented
+        if ($entryData->get('choice') == 'advancement') {
+            // advancement: increment character's level
+            $entryData['levels'] = 1;
+        } elseif ($entryData->get('choice') == 'magic_item') {
+            // magic_item: attach item to character of choice, and set entry's levels to 0
+            $itemData = [$itemData[0] ?? []];
+            $entryData['levels'] = 0;
+        } elseif ($entryData->get('choice') == 'campaign_reward') {
+            // campaign reward: set levels = 0, no item(s), should contain custom note
+            $itemData = [];
+            $entryData['levels'] = 0;
+        }
+
         $entry->update($entryData->toArray());
         CreateEntryItems::run($entry, $itemData['items'] ?? []);
         $request->session()->flash('entry.id', $entry->id);

--- a/app/Http/Requests/EntryStoreRequest.php
+++ b/app/Http/Requests/EntryStoreRequest.php
@@ -47,7 +47,8 @@ class EntryStoreRequest extends FormRequest
             'downtime' => ['sometimes', 'integer'],
             'items' => ['sometimes', 'array'],
             'items.*.name' => ['string', 'required_with:items'],
-            'items.*.rarity' => ["in:{$rarities}", 'required_with:items']
+            'items.*.rarity' => ["in:{$rarities}", 'required_with:items'],
+            'choice' => ['sometimes', 'string']
         ];
     }
 }

--- a/app/Http/Requests/EntryUpdateRequest.php
+++ b/app/Http/Requests/EntryUpdateRequest.php
@@ -44,7 +44,8 @@ class EntryUpdateRequest extends FormRequest
             'downtime' => ['sometimes', 'integer'],
             'items' => ['sometimes', 'array'],
             'items.*.name' => ['string', 'required_with:items'],
-            'items.*.rarity' => ["in:{$rarities}", 'required_with:items']
+            'items.*.rarity' => ["in:{$rarities}", 'required_with:items'],
+            'choice' => ['sometimes', 'string']
         ];
     }
 }

--- a/tests/Feature/Http/Controllers/DMEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/DMEntryControllerTest.php
@@ -71,8 +71,8 @@ class DMEntryControllerTest extends TestCase
         $date_played = $this->faker->dateTime();
         $location = $this->faker->word;
         $type = Entry::TYPE_DM;
-        $levels = $this->faker->numberBetween(1, 20);
         $gp = $this->faker->randomFloat(2, 0, 9999999.99);
+        $choice = 'advancement';
 
         $response = $this->actingAs($this->user)->post(route('entry.store'), [
             'user_id' => $this->user->id,
@@ -84,8 +84,8 @@ class DMEntryControllerTest extends TestCase
             'date_played' => $date_played,
             'location' => $location,
             'type' => $type,
-            'levels' => $levels,
             'gp' => $gp,
+            'choice' => $choice,
         ]);
 
         $entries = Entry::query()

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -270,6 +270,113 @@ class EntryControllerTest extends TestCase
         $this->assertCount(2, $entry->items);
     }
 
+    /**
+     * @test
+     */
+    public function store_handles_dm_reward_choice()
+    {
+        // Set Default Values for All Required Attributes of Entry
+        $adventure = Adventure::factory()->create();
+        $campaign = Campaign::factory()->create();
+        $character_adv = Character::factory()->create(['user_id' => $this->user->id]);
+        $character_MI = Character::factory()->create(['user_id' => $this->user->id]);
+        $character_CR = Character::factory()->create(['user_id' => $this->user->id]);
+        $event = Event::factory()->create();
+        $dungeon_master_user = User::factory()->create();
+        $dungeon_master = $this->faker->word;
+        $date_played = $this->faker->dateTime();
+        $location = $this->faker->word;
+        $type = Entry::TYPE_DM;
+        $levels = $this->faker->numberBetween(1, 20);
+        $gp = $this->faker->randomFloat(2, 0, 9999999.99);
+        $itemData = [
+            ['name' => "Longsword +1", 'rarity' => "uncommon"],
+            ['name' => "Amulet of Health", 'rarity' => "rare", 'description' => "Your Constitution score is 19 while you wear this amulet."]
+        ];
+        $choice_advancement = 'advancement';
+        $choice_item = 'magic_item';
+        $choice_rewards = 'campaign_reward';
+
+        //post request entry.store for each of them
+        $response_advancement = $this->actingAs($this->user)->post(route('entry.store'), [
+            'user_id' => $this->user->id,
+            'adventure_id' => $adventure->id,
+            'campaign_id' => $campaign->id,
+            'character_id' => $character_adv->id,
+            'event_id' => $event->id,
+            'dungeon_master_id' => $dungeon_master_user->id,
+            'dungeon_master' => $dungeon_master,
+            'date_played' => $date_played,
+            'location' => $location,
+            'type' => $type,
+            'levels' => $levels,
+            'gp' => $gp,
+            'choice' => $choice_advancement,
+
+        ]);
+
+        $response_MI = $this->actingAs($this->user)->post(route('entry.store'), [
+            'user_id' => $this->user->id,
+            'adventure_id' => $adventure->id,
+            'campaign_id' => $campaign->id,
+            'character_id' => $character_MI->id,
+            'event_id' => $event->id,
+            'dungeon_master_id' => $dungeon_master_user->id,
+            'dungeon_master' => $dungeon_master,
+            'date_played' => $date_played,
+            'location' => $location,
+            'type' => $type,
+            'levels' => $levels,
+            'gp' => $gp,
+            'items' => $itemData,
+            'choice' => $choice_item,
+
+        ]);
+
+        $response_CR = $this->actingAs($this->user)->post(route('entry.store'), [
+            'user_id' => $this->user->id,
+            'adventure_id' => $adventure->id,
+            'campaign_id' => $campaign->id,
+            'character_id' => $character_CR->id,
+            'event_id' => $event->id,
+            'dungeon_master_id' => $dungeon_master_user->id,
+            'dungeon_master' => $dungeon_master,
+            'date_played' => $date_played,
+            'location' => $location,
+            'type' => $type,
+            'levels' => $levels,
+            'gp' => $gp,
+            'choice' => $choice_rewards,
+
+        ]);
+
+        //Create the DM Entry for each of the above requests
+        $advancement_entry = Entry::query()
+            ->where('character_id', $character_adv->id)
+            ->first();
+
+        $magic_item_entry = Entry::query()
+            ->where('character_id', $character_MI->id)
+            ->where('user_id', $this->user->id)
+            ->first();
+
+        $campaign_reward_entry = Entry::query()
+            ->where('character_id', $character_CR->id)
+            ->first();
+
+        //advancement assertions
+        $this->assertEquals(1, $advancement_entry->levels);
+        $this->assertCount(0, $advancement_entry->items);
+
+        //reward_item assertions
+        $this->assertEquals(0, $magic_item_entry->levels);
+        $this->assertCount(1, $magic_item_entry->items);
+
+        //campaign_reward assertions
+        $this->assertEquals(0, $campaign_reward_entry->levels);
+        $this->assertCount(0, $campaign_reward_entry->items);
+    }
+
 
     /**
      * @test
@@ -419,7 +526,6 @@ class EntryControllerTest extends TestCase
         $date_played = $this->faker->dateTime();
         $location = $this->faker->word;
         $type = Entry::TYPE_DM;
-        $levels = 5;
         $gp = $this->faker->randomFloat(2, 0, 9999999.99);
 
         $response = $this->actingAs($this->user)->post(route('entry.store'), [
@@ -433,13 +539,12 @@ class EntryControllerTest extends TestCase
             'date_played' => $date_played,
             'location' => $location,
             'type' => $type,
-            'levels' => $levels,
             'gp' => $gp,
+            'choice' => 'advancement'
         ]);
 
         $character->refresh();
-
-        $this->assertEquals($oldLevel + $levels, $character->level);
+        $this->assertEquals($oldLevel + 1, $character->level);
     }
 
     /**
@@ -453,7 +558,6 @@ class EntryControllerTest extends TestCase
 
         $entry = Entry::factory()->create([
             'type' => Entry::TYPE_DM,
-            'levels' => 3,
         ]);
 
         $character->user()->associate($this->user)->save();
@@ -469,7 +573,6 @@ class EntryControllerTest extends TestCase
         $date_played = $this->faker->dateTime();
         $location = $this->faker->word;
         $type = Entry::TYPE_DM;
-        $levels = 5;
         $gp = $this->faker->randomFloat(2, 0, 9999999.99);
 
         $response = $this->actingAs($this->user)->put(route('entry.update', $entry), [
@@ -481,13 +584,13 @@ class EntryControllerTest extends TestCase
             'date_played' => $date_played,
             'location' => $location,
             'type' => $type,
-            'levels' => $levels,
             'gp' => $gp,
+            'choice' => 'advancement',
         ]);
 
         $character->refresh();
 
-        $this->assertEquals(5, $character->level);
+        $this->assertEquals(1, $character->level);
     }
 
     /**


### PR DESCRIPTION
### Description

Closes #184 

Adds EntryController logic to process store and update requests for DM Entries which contain a reward choice. The possible choices include advancement, magic_item and campaign_reward. The store and update requests must modify the items or levels attributes in the entry based on the reward choice. 

