### PR TITLE
Rating Categories

### DIFF
--- a/app/Http/Requests/RatingStoreRequest.php
+++ b/app/Http/Requests/RatingStoreRequest.php
@@ -27,6 +27,7 @@ class RatingStoreRequest extends FormRequest
             'entry_id' => ['required', 'integer', 'exists:entries,id'],
             'user_id' => ['required', 'integer', 'exists:users,id'],
             'author_id' => ['required', 'integer', 'exists:users,id'],
+            'categories' => ['required', 'integer'],
         ];
     }
 }

--- a/app/Http/Requests/RatingStoreRequest.php
+++ b/app/Http/Requests/RatingStoreRequest.php
@@ -27,7 +27,6 @@ class RatingStoreRequest extends FormRequest
             'entry_id' => ['required', 'integer', 'exists:entries,id'],
             'user_id' => ['required', 'integer', 'exists:users,id'],
             'author_id' => ['required', 'integer', 'exists:users,id'],
-            'score' => ['required', 'string'],
         ];
     }
 }

--- a/app/Http/Requests/RatingUpdateRequest.php
+++ b/app/Http/Requests/RatingUpdateRequest.php
@@ -27,6 +27,7 @@ class RatingUpdateRequest extends FormRequest
             'entry_id' => ['required', 'integer', 'exists:entries,id'],
             'user_id' => ['required', 'integer', 'exists:users,id'],
             'author_id' => ['required', 'integer', 'exists:users,id'],
+            'categories' => ['required', 'integer'],
         ];
     }
 }

--- a/app/Http/Requests/RatingUpdateRequest.php
+++ b/app/Http/Requests/RatingUpdateRequest.php
@@ -27,7 +27,6 @@ class RatingUpdateRequest extends FormRequest
             'entry_id' => ['required', 'integer', 'exists:entries,id'],
             'user_id' => ['required', 'integer', 'exists:users,id'],
             'author_id' => ['required', 'integer', 'exists:users,id'],
-            'score' => ['required', 'string'],
         ];
     }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -119,4 +119,25 @@ class Rating extends Model
 
         return $bitmasks->only($bits);
     }
+
+    public function scopeHasCategories($query, $bits)
+    {
+        $this->queryCategoriesBitmask($query, $bits, $containsCategories = true);
+    }
+
+    public function scopeMissingCategories($query, $bits)
+    {
+        $this->queryCategoriesBitmask($query, $bits, $containsCategories = true);
+    }
+
+    protected function queryCategoriesBitmask($query, $bits, $containsCategories)
+    {
+        $bits = array_sum(Arr::wrap($bits));
+
+        $queryOperator = $containsCategories ? '=' : '!=';
+
+        //build the query
+        // (categories & bits) <operator> bits
+        $query->whereRaw("categories & $bits $queryOperator $bits");
+    }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 class Rating extends Model
 {
@@ -127,17 +128,16 @@ class Rating extends Model
 
     public function scopeMissingCategories($query, $bits)
     {
-        $this->queryCategoriesBitmask($query, $bits, $containsCategories = true);
+        $this->queryCategoriesBitmask($query, $bits, $containsCategories = false);
     }
 
     protected function queryCategoriesBitmask($query, $bits, $containsCategories)
     {
         $bits = array_sum(Arr::wrap($bits));
-
         $queryOperator = $containsCategories ? '=' : '!=';
 
         //build the query
-        // (categories & bits) <operator> bits
+        //(categories & bits) <operator> bits
         $query->whereRaw("categories & $bits $queryOperator $bits");
     }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -19,6 +19,7 @@ class Rating extends Model
         'user_id',
         'author_id',
         'score',
+        'categories',
     ];
 
     /**
@@ -31,7 +32,14 @@ class Rating extends Model
         'entry_id' => 'integer',
         'user_id' => 'integer',
         'author_id' => 'integer',
+        'categories' => 'integer',
     ];
+
+    public const CREATIVE_BITMASK = 1 << 0;    // 00001
+    public const FLEXIBLE_BITMASK = 1 << 1;    // 00010
+    public const FRIENDLY_BITMASK = 1 << 2;    // 00100
+    public const HELPFUL_BITMASK = 1 << 3;     // 01000
+    public const PREPARED_BITMASK = 1 << 4;    // 10000
 
 
     public function entry()
@@ -47,5 +55,34 @@ class Rating extends Model
     public function author()
     {
         return $this->belongsTo(\App\Models\User::class);
+    }
+
+    /**
+     * Determines if the rating instance has a category given by the passed parameter
+     * @param $bitMask
+     * bitmask param should always be one of the bitmask constants defined on this model
+     * @return bool
+     */
+    public function hasCategory($bitMask)
+    {
+        return ($this->categories & $bitMask) === $bitMask;
+    }
+
+    /**
+     * Adds a category given by the bitmask parameter, which should be one of the bitmask constants defined on this model
+     * @param $bitMask
+     */
+    public function addCategory($bitMask)
+    {
+        $this->categories |= $bitMask;
+    }
+
+    /**
+     * Removes a category given by the bitmask parameter, which should be one of the bitmask constants defined on this model
+     * @param $bitMask
+     */
+    public function removeCategory($bitMask)
+    {
+        $this->categories &= ~$bitMask;
     }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -123,24 +123,31 @@ class Rating extends Model
      */
     private function getCategoryLabelFromMask($mask)
     {
+        $label = "";
         switch ($mask) {
             case self::CREATIVE_BITMASK:
-                return self::CREATIVE_LABEL;
+                $label = self::CREATIVE_LABEL;
+                break;
 
             case self::FLEXIBLE_BITMASK:
-                return self::FLEXIBLE_LABEL;
+                $label = self::FLEXIBLE_LABEL;
+                break;
 
             case self::FRIENDLY_BITMASK:
-                return self::FRIENDLY_LABEL;
+                $label = self::FRIENDLY_LABEL;
+                break;
 
             case self::HELPFUL_BITMASK:
-                return self::HELPFUL_LABEL;
+                $label = self::HELPFUL_LABEL;
+                break;
 
             case self::PREPARED_BITMASK:
-                return self::PREPARED_LABEL;
+                $label = self::PREPARED_LABEL;
+                break;
 
             default:
-                return "";
+                $label = "";
         }
+        return $label;
     }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -121,12 +121,12 @@ class Rating extends Model
         return $bitmasks->only($bits);
     }
 
-    public function scopeHasCategories($query, $bits)
+    public function scopeWithCategories($query, $bits)
     {
         $this->queryCategoriesBitmask($query, $bits, $containsCategories = true);
     }
 
-    public function scopeMissingCategories($query, $bits)
+    public function scopeWithoutCategories($query, $bits)
     {
         $this->queryCategoriesBitmask($query, $bits, $containsCategories = false);
     }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -99,7 +99,6 @@ class Rating extends Model
      */
     public function getLabelsAttribute()
     {
-        $labels = collect();
         $bitmasks = collect([
             self::CREATIVE_BITMASK => self::CREATIVE_LABEL,
             self::FLEXIBLE_BITMASK => self::FLEXIBLE_LABEL,

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -18,7 +18,6 @@ class Rating extends Model
         'entry_id',
         'user_id',
         'author_id',
-        'score',
         'categories',
     ];
 

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -96,58 +96,27 @@ class Rating extends Model
      * Returns category labels. Not recommended for large batches of requests, instead use hasCategory with bitmask
      * @returns Collection of strings corresponding to the rating categories of this entity
      */
-    public function getCategoryLabels()
+    public function getLabelsAttribute()
     {
         $labels = collect();
         $bitmasks = collect([
-            self::CREATIVE_BITMASK,
-            self::FLEXIBLE_BITMASK,
-            self::FRIENDLY_BITMASK,
-            self::HELPFUL_BITMASK,
-            self::PREPARED_BITMASK,
+            self::CREATIVE_BITMASK => self::CREATIVE_LABEL,
+            self::FLEXIBLE_BITMASK => self::FLEXIBLE_LABEL,
+            self::FRIENDLY_BITMASK => self::FRIENDLY_LABEL,
+            self::HELPFUL_BITMASK => self::HELPFUL_LABEL,
+            self::PREPARED_BITMASK => self::PREPARED_LABEL,
         ]);
 
-        foreach ($bitmasks as $mask) {
-            if ($this->hasCategory($mask)) {
-                $labels->push($this->getCategoryLabelFromMask($mask));
+        //bit decomposition of the categories
+        $bitFilter = 1;
+        $bits = [];
+        while ($bitFilter <= $this->categories) {
+            if ($bitFilter & $this->categories) {
+                $bits[] = $bitFilter;
             }
+            $bitFilter = $bitFilter << 1;
         }
 
-        return $labels;
-    }
-
-    /**
-     * Get category label corresponding to a bitmask
-     * @param $mask integer The bitmask
-     * @return string The Label
-     */
-    private function getCategoryLabelFromMask($mask)
-    {
-        $label = "";
-        switch ($mask) {
-            case self::CREATIVE_BITMASK:
-                $label = self::CREATIVE_LABEL;
-                break;
-
-            case self::FLEXIBLE_BITMASK:
-                $label = self::FLEXIBLE_LABEL;
-                break;
-
-            case self::FRIENDLY_BITMASK:
-                $label = self::FRIENDLY_LABEL;
-                break;
-
-            case self::HELPFUL_BITMASK:
-                $label = self::HELPFUL_LABEL;
-                break;
-
-            case self::PREPARED_BITMASK:
-                $label = self::PREPARED_LABEL;
-                break;
-
-            default:
-                $label = "";
-        }
-        return $label;
+        return $bitmasks->only($bits);
     }
 }

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -39,6 +40,12 @@ class Rating extends Model
     public const FRIENDLY_BITMASK = 1 << 2;    // 00100
     public const HELPFUL_BITMASK = 1 << 3;     // 01000
     public const PREPARED_BITMASK = 1 << 4;    // 10000
+
+    public const CREATIVE_LABEL = "CREATIVE";
+    public const FLEXIBLE_LABEL = "FLEXIBLE";
+    public const FRIENDLY_LABEL = "FRIENDLY";
+    public const HELPFUL_LABEL = "HELPFUL";
+    public const PREPARED_LABEL = "PREPARED";
 
 
     public function entry()
@@ -83,5 +90,57 @@ class Rating extends Model
     public function removeCategory($bitMask)
     {
         $this->categories &= ~$bitMask;
+    }
+
+    /**
+     * Returns category labels. Not recommended for large batches of requests, instead use hasCategory with bitmask
+     * @returns Collection of strings corresponding to the rating categories of this entity
+     */
+    public function getCategoryLabels()
+    {
+        $labels = collect();
+        $bitmasks = collect([
+            self::CREATIVE_BITMASK,
+            self::FLEXIBLE_BITMASK,
+            self::FRIENDLY_BITMASK,
+            self::HELPFUL_BITMASK,
+            self::PREPARED_BITMASK,
+        ]);
+
+        foreach ($bitmasks as $mask) {
+            if ($this->hasCategory($mask)) {
+                $labels->push($this->getCategoryLabelFromMask($mask));
+            }
+        }
+
+        return $labels;
+    }
+
+    /**
+     * Get category label corresponding to a bitmask
+     * @param $mask integer The bitmask
+     * @return string The Label
+     */
+    private function getCategoryLabelFromMask($mask)
+    {
+        switch ($mask) {
+            case self::CREATIVE_BITMASK:
+                return self::CREATIVE_LABEL;
+
+            case self::FLEXIBLE_BITMASK:
+                return self::FLEXIBLE_LABEL;
+
+            case self::FRIENDLY_BITMASK:
+                return self::FRIENDLY_LABEL;
+
+            case self::HELPFUL_BITMASK:
+                return self::HELPFUL_LABEL;
+
+            case self::PREPARED_BITMASK:
+                return self::PREPARED_LABEL;
+
+            default:
+                return "";
+        }
     }
 }

--- a/database/factories/RatingFactory.php
+++ b/database/factories/RatingFactory.php
@@ -28,7 +28,7 @@ class RatingFactory extends Factory
             'entry_id' => Entry::factory(),
             'user_id' => User::factory(),
             'author_id' => User::factory(),
-            'score' => $this->faker->word(),
+            'categories' => $this->faker->numberBetween(1, 31) //31 hardcoded because 5 categories all active would be 31 in binary (11111)
         ];
     }
 }

--- a/database/migrations/2021_12_27_200344_add_categories_to_ratings_table.php
+++ b/database/migrations/2021_12_27_200344_add_categories_to_ratings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCategoriesToRatingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ratings', function (Blueprint $table) {
+            $table->integer('categories')->unsigned()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('ratings', function (Blueprint $table) {
+            $table->dropColumn('length');
+        });
+    }
+}

--- a/database/migrations/2021_12_27_200344_add_categories_to_ratings_table.php
+++ b/database/migrations/2021_12_27_200344_add_categories_to_ratings_table.php
@@ -26,7 +26,7 @@ class AddCategoriesToRatingsTable extends Migration
     public function down()
     {
         Schema::table('ratings', function (Blueprint $table) {
-            $table->dropColumn('length');
+            $table->dropColumn('categories');
         });
     }
 }

--- a/database/migrations/2021_12_27_211938_drop_score_from_ratings_table.php
+++ b/database/migrations/2021_12_27_211938_drop_score_from_ratings_table.php
@@ -26,7 +26,7 @@ class DropScoreFromRatingsTable extends Migration
     public function down()
     {
         Schema::table('ratings', function (Blueprint $table) {
-            //
+            $table->string('score')
         });
     }
 }

--- a/database/migrations/2021_12_27_211938_drop_score_from_ratings_table.php
+++ b/database/migrations/2021_12_27_211938_drop_score_from_ratings_table.php
@@ -26,7 +26,7 @@ class DropScoreFromRatingsTable extends Migration
     public function down()
     {
         Schema::table('ratings', function (Blueprint $table) {
-            $table->string('score')
+            $table->string('score');
         });
     }
 }

--- a/database/migrations/2021_12_27_211938_drop_score_from_ratings_table.php
+++ b/database/migrations/2021_12_27_211938_drop_score_from_ratings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropScoreFromRatingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('ratings', function (Blueprint $table) {
+            $table->dropColumn('score');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('ratings', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/tests/Feature/Http/Controllers/RatingControllerTest.php
+++ b/tests/Feature/Http/Controllers/RatingControllerTest.php
@@ -76,20 +76,20 @@ class RatingControllerTest extends TestCase
         $entry = Entry::factory()->create();
         $user = User::factory()->create();
         $author = User::factory()->create();
-        $score = $this->faker->word;
+        $categories = 0;
 
         $response = $this->post(route('rating.store'), [
             'entry_id' => $entry->id,
             'user_id' => $user->id,
             'author_id' => $author->id,
-            'score' => $score,
+            'categories' => $categories,
         ]);
 
         $ratings = Rating::query()
             ->where('entry_id', $entry->id)
             ->where('user_id', $user->id)
             ->where('author_id', $author->id)
-            ->where('score', $score)
+            ->where('categories', $categories)
             ->get();
         $this->assertCount(1, $ratings);
         $rating = $ratings->first();
@@ -150,13 +150,13 @@ class RatingControllerTest extends TestCase
         $entry = Entry::factory()->create();
         $user = User::factory()->create();
         $author = User::factory()->create();
-        $score = $this->faker->word;
+        $categories = 4;
 
         $response = $this->put(route('rating.update', $rating), [
             'entry_id' => $entry->id,
             'user_id' => $user->id,
             'author_id' => $author->id,
-            'score' => $score,
+            'categories' => $categories,
         ]);
 
         $rating->refresh();
@@ -167,7 +167,7 @@ class RatingControllerTest extends TestCase
         $this->assertEquals($entry->id, $rating->entry_id);
         $this->assertEquals($user->id, $rating->user_id);
         $this->assertEquals($author->id, $rating->author_id);
-        $this->assertEquals($score, $rating->score);
+        $this->assertEquals($categories, $rating->categories);
     }
 
 

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -93,7 +93,7 @@ class RatingTest extends TestCase
     {
         $categories = Rating::FLEXIBLE_BITMASK + Rating::FRIENDLY_BITMASK + Rating::CREATIVE_BITMASK + Rating::HELPFUL_BITMASK + Rating::PREPARED_BITMASK;
         $rating = Rating::factory()->create(['categories' => $categories]);
-        $labels = $rating->getCategoryLabels();
+        $labels = $rating->getLabelsAttribute();
 
         $this->assertContains(Rating::FLEXIBLE_LABEL, $labels);
         $this->assertContains(Rating::HELPFUL_LABEL, $labels);

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -102,4 +102,30 @@ class RatingTest extends TestCase
         $this->assertContains(Rating::CREATIVE_LABEL, $labels);
         $this->assertCount(5, $labels);
     }
+
+    /**
+     * @test
+     */
+    public function can_scope_queries_to_categories()
+    {
+        $categories1 = Rating::FLEXIBLE_BITMASK + Rating::FRIENDLY_BITMASK;
+        $categories2 = Rating::HELPFUL_BITMASK + Rating::FRIENDLY_BITMASK;
+        $categories3 = Rating::PREPARED_BITMASK + Rating::HELPFUL_BITMASK;
+
+        $rating1 = Rating::factory()->create(['categories' => $categories1]);
+        $rating2 = Rating::factory()->create(['categories' => $categories2]);
+        $rating3 = Rating::factory()->create(['categories' => $categories3]);
+
+        $friendlyHelpfulRating = Rating::hasCategories([
+            Rating::FRIENDLY_BITMASK,
+            Rating::HELPFUL_BITMASK,
+        ])->first();
+
+        $this->assertTrue($friendlyHelpfulRating->hasCategory(Rating::FRIENDLY_BITMASK));
+        $this->assertTrue($friendlyHelpfulRating->hasCategory(Rating::HELPFUL_BITMASK));
+
+        $notFriendlyRating = Rating::missingCategories(Rating::FRIENDLY_BITMASK)->first();
+
+        $this->assertFalse($notFriendlyRating->hasCategory(Rating::FRIENDLY_BITMASK));
+    }
 }

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -40,4 +40,37 @@ class RatingTest extends TestCase
         $rating = Rating::factory(1)->create()[0];
         $this->assertCount(1, $rating->author()->get());
     }
+
+    /**
+     * @test
+     */
+    public function can_add_categories()
+    {
+        $rating = Rating::factory()->create(['categories' => 0]);
+        $rating->addCategory(Rating::CREATIVE_BITMASK);
+        $this->assertTrue($rating->hasCategory(Rating::CREATIVE_BITMASK));
+    }
+
+    /**
+     * @test
+     */
+    public function has_category_helper_function_test()
+    {
+        $rating = Rating::factory()->create(['categories' => 0]);
+        $rating->categories = Rating::FRIENDLY_BITMASK;
+        $rating->save();
+        $this->assertTrue($rating->hasCategory(Rating::FRIENDLY_BITMASK));
+        $this->assertFalse($rating->hasCategory(Rating::CREATIVE_BITMASK));
+    }
+
+    /**
+     * @test
+     */
+    public function can_have_multiple_categories()
+    {
+        $categories = Rating::CREATIVE_BITMASK + Rating::FRIENDLY_BITMASK;
+        $rating = Rating::factory()->create(['categories' => $categories]);
+        $this->assertTrue($rating->hasCategory(Rating::CREATIVE_BITMASK));
+        $this->assertTrue($rating->hasCategory(Rating::FRIENDLY_BITMASK));
+    }
 }

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -116,7 +116,7 @@ class RatingTest extends TestCase
         $rating2 = Rating::factory()->create(['categories' => $categories2]);
         $rating3 = Rating::factory()->create(['categories' => $categories3]);
 
-        $friendlyHelpfulRating = Rating::hasCategories([
+        $friendlyHelpfulRating = Rating::withCategories([
             Rating::FRIENDLY_BITMASK,
             Rating::HELPFUL_BITMASK,
         ])->first();
@@ -124,7 +124,7 @@ class RatingTest extends TestCase
         $this->assertTrue($friendlyHelpfulRating->hasCategory(Rating::FRIENDLY_BITMASK));
         $this->assertTrue($friendlyHelpfulRating->hasCategory(Rating::HELPFUL_BITMASK));
 
-        $notFriendlyRating = Rating::missingCategories(Rating::FRIENDLY_BITMASK)->first();
+        $notFriendlyRating = Rating::withoutCategories(Rating::FRIENDLY_BITMASK)->first();
 
         $this->assertFalse($notFriendlyRating->hasCategory(Rating::FRIENDLY_BITMASK));
     }

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -91,13 +91,15 @@ class RatingTest extends TestCase
      */
     public function can_get_category_labels()
     {
-        $categories = Rating::FLEXIBLE_BITMASK + Rating::HELPFUL_BITMASK + Rating::PREPARED_BITMASK;
+        $categories = Rating::FLEXIBLE_BITMASK + Rating::FRIENDLY_BITMASK + Rating::CREATIVE_BITMASK + Rating::HELPFUL_BITMASK + Rating::PREPARED_BITMASK;
         $rating = Rating::factory()->create(['categories' => $categories]);
         $labels = $rating->getCategoryLabels();
 
         $this->assertContains(Rating::FLEXIBLE_LABEL, $labels);
         $this->assertContains(Rating::HELPFUL_LABEL, $labels);
         $this->assertContains(Rating::PREPARED_LABEL, $labels);
-        $this->assertCount(3, $labels);
+        $this->assertContains(Rating::FRIENDLY_LABEL, $labels);
+        $this->assertContains(Rating::CREATIVE_LABEL, $labels);
+        $this->assertCount(5, $labels);
     }
 }

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -112,9 +112,9 @@ class RatingTest extends TestCase
         $categories2 = Rating::HELPFUL_BITMASK + Rating::FRIENDLY_BITMASK;
         $categories3 = Rating::PREPARED_BITMASK + Rating::HELPFUL_BITMASK;
 
-        $rating1 = Rating::factory()->create(['categories' => $categories1]);
-        $rating2 = Rating::factory()->create(['categories' => $categories2]);
-        $rating3 = Rating::factory()->create(['categories' => $categories3]);
+        Rating::factory()->create(['categories' => $categories1]);
+        Rating::factory()->create(['categories' => $categories2]);
+        Rating::factory()->create(['categories' => $categories3]);
 
         $friendlyHelpfulRating = Rating::withCategories([
             Rating::FRIENDLY_BITMASK,

--- a/tests/Unit/Models/RatingTest.php
+++ b/tests/Unit/Models/RatingTest.php
@@ -73,4 +73,31 @@ class RatingTest extends TestCase
         $this->assertTrue($rating->hasCategory(Rating::CREATIVE_BITMASK));
         $this->assertTrue($rating->hasCategory(Rating::FRIENDLY_BITMASK));
     }
+
+    /**
+     * @test
+     */
+    public function can_remove_categories()
+    {
+        $categories = Rating::CREATIVE_BITMASK + Rating::FRIENDLY_BITMASK;
+        $rating = Rating::factory()->create(['categories' => $categories]);
+        $rating->removeCategory(Rating::FRIENDLY_BITMASK);
+        $this->assertTrue($rating->hasCategory(Rating::CREATIVE_BITMASK));
+        $this->assertFalse($rating->hasCategory(Rating::FRIENDLY_BITMASK));
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_category_labels()
+    {
+        $categories = Rating::FLEXIBLE_BITMASK + Rating::HELPFUL_BITMASK + Rating::PREPARED_BITMASK;
+        $rating = Rating::factory()->create(['categories' => $categories]);
+        $labels = $rating->getCategoryLabels();
+
+        $this->assertContains(Rating::FLEXIBLE_LABEL, $labels);
+        $this->assertContains(Rating::HELPFUL_LABEL, $labels);
+        $this->assertContains(Rating::PREPARED_LABEL, $labels);
+        $this->assertCount(3, $labels);
+    }
 }


### PR DESCRIPTION
## Description
Closes #205 
Adds the 'categories' field to the Ratings model, which is an integer that tracks which categories of rating a given rating instance has by making use of bit manipulation and bitmasks.

Also adds two query scopes which can be used to filter by rating category, they are
- Rating::withCategories()
- Rating::withoutCategories()

An example of a query using one of the above scopes:
`$friendlyHelpfulRating = Rating::withCategories([
            Rating::FRIENDLY_BITMASK,
            Rating::HELPFUL_BITMASK,
        ])->first();`

Also removes the score field from Ratings model, which is no longer needed due to the updated design of the rating system.

## How to test
open tinker and create a Rating instance, call it `$rating`

Observe the categories field, if it is non zero run the following command, if it is zero it is not a problem, simple skip this command, or run it if you'd like to see an empty list.
`$rating->labels`
Observe the list of rating categories

Next, add a category, selecting from one of the five bitmask constants declared on the Model. 
For your convenience, here is a list of the categories: [CREATIVE, FLEXIBLE, FRIENDLY, HELPFUL, PREPARED]
(example command below)
`$rating->addCategory(Rating::PREPARED_BITMASK)`

Now, check that the category has been added by re running the label list command from earlier.
`$rating->labels`

Next, remove a category, again selecting a category that fits your case.
`$rating->removeCategory(Rating::PREPARED_BITMASK)`

Finally, check that the category has been removed.
`$rating->labels`



