### PR TITLE
Fix Item Entry Edit Bug

### DIFF
--- a/app/Actions/CreateEntryItems.php
+++ b/app/Actions/CreateEntryItems.php
@@ -21,10 +21,7 @@ class CreateEntryItems
     {
         $out = collect();
 
-        if ($entry->items()->count() >= count($items)) {
-            // This is probably a "sync" so clear the existing items
-            $entry->items()->delete();
-        }
+        $entry->items()->delete();
 
         foreach ($items as $item) {
             $out[] = new Item(


### PR DESCRIPTION
## Description
Closes #209 
Removes item count guard condition in CreateEntryItems action.
This guard condition made it possible to have items not be removed when they should be.
For example a user removes one item and then adds two new ones to a given entry as part of an edit, then with the guard condition the item to be removed would not have been removed.