### PR TITLE
Fix Integrity Constraint Error When Deleting Characters

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableInterface;
 use Illuminate\Notifications\Notifiable;
@@ -16,6 +17,7 @@ class User extends Authenticatable implements AuthenticatableInterface
     use HasApiTokens;
     use HasFactory;
     use Notifiable;
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.
@@ -81,6 +83,11 @@ class User extends Authenticatable implements AuthenticatableInterface
         return $this->hasManyThrough(\App\Models\Item::class, \App\Models\Character::class);
     }
 
+    public function authored_items()
+    {
+        return $this->hasMany(\App\Models\Item::class, "author_id");
+    }
+
     public function ratings()
     {
         return $this->hasMany(\App\Models\Rating::class);
@@ -135,7 +142,7 @@ class User extends Authenticatable implements AuthenticatableInterface
             Rating::HELPFUL_LABEL,
             Rating::PREPARED_LABEL
         ];
-        
+
         $total = collect([
             $labels[0] => 0,
             $labels[1] => 0,

--- a/app/Observers/CharacterObserver.php
+++ b/app/Observers/CharacterObserver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Character;
+
+class CharacterObserver
+{
+    /**
+     * Handle the Character "deleting" event.
+     *
+     * @param  \App\Models\Character  $character
+     * @return void
+     */
+    public function deleting(Character $character)
+    {
+        $character->entries->each(function ($entry) {
+            $entry->character_id = null;
+            $entry->save();
+        });
+    }
+}

--- a/app/Observers/CharacterObserver.php
+++ b/app/Observers/CharacterObserver.php
@@ -8,6 +8,8 @@ class CharacterObserver
 {
     /**
      * Handle the Character "deleting" event.
+     * Detach all entries from a character marked for deletion.
+     * This allows all rating associated with these entries to remain in our system.
      *
      * @param  \App\Models\Character  $character
      * @return void

--- a/app/Observers/EntryObserver.php
+++ b/app/Observers/EntryObserver.php
@@ -48,7 +48,7 @@ class EntryObserver
             }
 
             // entry level unchanged but character newly attached -> add level to character
-            elseif ($dirtyCharacter) {
+            elseif (!is_null($character) && $dirtyCharacter) {
                 $character->level = (is_null($character->level))
                     ? $entry->levels
                     : $character->level + $entry->levels;

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\Character;
 use App\Models\Entry;
+use App\Observers\CharacterObserver;
 use App\Observers\EntryObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -31,5 +32,6 @@ class EventServiceProvider extends ServiceProvider
     public function boot()
     {
         Entry::observe(EntryObserver::class);
+        Character::observe(CharacterObserver::class);
     }
 }

--- a/database/migrations/2022_01_12_015440_add_cascades_to_items_table.php
+++ b/database/migrations/2022_01_12_015440_add_cascades_to_items_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCascadesToItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            Schema::disableForeignKeyConstraints();
+            $table->dropForeign('items_character_id_foreign');
+            $table->dropForeign('items_entry_id_foreign');
+
+            $table->foreign('character_id')
+                ->references('id')
+                ->on('characters')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+
+            $table->foreign('entry_id')
+                ->references('id')
+                ->on('entries')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            Schema::enableForeignKeyConstraints();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('items', function (Blueprint $table) {
+            Schema::disableForeignKeyConstraints();
+
+            $table->dropForeign('items_character_id_foreign');
+            $table->dropForeign('items_entry_id_foreign');
+
+            $table->foreign('character_id')
+                ->references('id')
+                ->on('characters');
+
+            $table->foreign('entry_id')
+                ->references('id')
+                ->on('entries');
+
+            Schema::enableForeignKeyConstraints();
+        });
+    }
+}

--- a/database/migrations/2022_01_12_015440_add_cascades_to_items_table.php
+++ b/database/migrations/2022_01_12_015440_add_cascades_to_items_table.php
@@ -18,12 +18,15 @@ class AddCascadesToItemsTable extends Migration
             $table->dropForeign('items_character_id_foreign');
             $table->dropForeign('items_entry_id_foreign');
 
+            // If a character with items still attached is deleted, remove the associated items via a cascade constraint.
+
             $table->foreign('character_id')
                 ->references('id')
                 ->on('characters')
                 ->cascadeOnDelete()
                 ->cascadeOnUpdate();
 
+            // Same concept as above, if an entry is deleted, remove the associated items.
             $table->foreign('entry_id')
                 ->references('id')
                 ->on('entries')

--- a/database/migrations/2022_01_12_021419_add_soft_deletes_to_users_table.php
+++ b/database/migrations/2022_01_12_021419_add_soft_deletes_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSoftDeletesToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('deleted_at');
+        });
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use App\Models\Event;
 use App\Models\Item;
 use App\Models\League;
 use App\Models\Rating;
+use App\Models\Role;
 use App\Models\Session;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
@@ -23,10 +24,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
+        $this->call(RoleSeeder::class);
+        $defaultUser = User::factory()->hasAttached(Role::first())->create([
+            'email' => 'default@test.com',
+            'name' => "Test account"
+        ]);
+
         $dndmtl = League::factory()->create([
             'name' => "DnD MTL"
         ]);
-        $users = User::factory(10)->create();
+        $users = User::factory(10)->create()->prepend($defaultUser);
         $dm = User::factory(5)->create();
         $events = Event::factory(5)->create([
             'league_id' => $dndmtl->id

--- a/tests/Feature/Http/Controllers/UserControllerTest.php
+++ b/tests/Feature/Http/Controllers/UserControllerTest.php
@@ -144,6 +144,6 @@ class UserControllerTest extends TestCase
 
         $response->assertRedirect(route('user.index'));
 
-        $this->assertDeleted($user);
+        $this->assertSoftDeleted($user);
     }
 }

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -133,6 +133,9 @@ class UserTest extends TestCase
         $this->assertEquals($expectedTotal, $actualTotal);
     }
 
+    /**
+     * @test
+     */
     public function user_has_authored_items()
     {
         $user = User::factory()->create();
@@ -141,6 +144,6 @@ class UserTest extends TestCase
         ]);
 
         $this->assertCount(3, $user->authored_items);
-        $this->assertEquals($items, $user->authored_items);
+        $this->assertEquals($items->fresh(), $user->authored_items);
     }
 }

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -20,17 +20,7 @@ class UserTest extends TestCase
     use RefreshDatabase;
     use WithFaker;
 
-    /**
-     * A basic unit test example.
-     *
-     * @return void
-     */
-    public function test_example()
-    {
-        $this->assertTrue(true);
-    }
-
-    public function test_user_is_admin_returns_true_if_admin()
+    public function user_is_admin_returns_true_if_admin()
     {
         $testUser = User::factory()->create();
 
@@ -44,14 +34,20 @@ class UserTest extends TestCase
         $this->assertTrue($testUser->isSiteAdmin());
     }
 
-    public function test_user_is_admin_returns_false_if_not_admin()
+    /**
+     * @test
+     */
+    public function user_is_admin_returns_false_if_not_admin()
     {
         $testUser = User::factory()->create();
 
         $this->assertFalse($testUser->isSiteAdmin());
     }
 
-    public function test_user_has_league_role()
+    /**
+     * @test
+     */
+    public function user_has_league_role()
     {
         $testUser = User::factory()->create();
         $testLeague = League::factory()->create();
@@ -66,7 +62,10 @@ class UserTest extends TestCase
         $this->AssertFalse(User::factory()->create()->isLeagueAdmin($testLeague->id));
     }
 
-    public function test_user_has_any_role_returns_false()
+    /**
+     * @test
+     */
+    public function user_has_any_role_returns_false()
     {
         $testUser = User::factory()->create();
         $testRole = Role::create([
@@ -77,7 +76,11 @@ class UserTest extends TestCase
 
         $this->AssertFalse($testUser->hasAnyRole());
     }
-    public function test_user_has_any_role_returns_true()
+
+    /**
+     * @test
+     */
+    public function user_has_any_role_returns_true()
     {
         $testUser = User::factory()->create();
         $testRole = Role::create([
@@ -128,5 +131,16 @@ class UserTest extends TestCase
         ]);
 
         $this->assertEquals($expectedTotal, $actualTotal);
+    }
+
+    public function user_has_authored_items()
+    {
+        $user = User::factory()->create();
+        $items = Item::factory(3)->create([
+            'author_id' => $user->id
+        ]);
+
+        $this->assertCount(3, $user->authored_items);
+        $this->assertEquals($items, $user->authored_items);
     }
 }

--- a/tests/Unit/Observers/CharacterObserver.php
+++ b/tests/Unit/Observers/CharacterObserver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\Observers;
+
+use App\Models\Character;
+use App\Models\Entry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use JMac\Testing\Traits\AdditionalAssertions;
+use Tests\TestCase;
+
+class CharacterObserver extends TestCase
+{
+    use AdditionalAssertions;
+    use RefreshDatabase;
+    use WithFaker;
+
+    /**
+     * @test
+     */
+    public function a_deleted_characters_items_remain_after_deletion()
+    {
+        $character = Character::factory()->has(Entry::factory(3))->create();
+
+        $character->delete();
+
+
+        $this->assertDatabaseCount(Entry::class, 3);
+        Entry::all()->each(function ($entry) {
+            $this->assertNull($entry->character_id);
+        });
+    }
+}

--- a/tests/Unit/Observers/CharacterObserverTest.php
+++ b/tests/Unit/Observers/CharacterObserverTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
 use Tests\TestCase;
 
-class CharacterObserver extends TestCase
+class CharacterObserverTest extends TestCase
 {
     use AdditionalAssertions;
     use RefreshDatabase;
@@ -23,7 +23,6 @@ class CharacterObserver extends TestCase
         $character = Character::factory()->has(Entry::factory(3))->create();
 
         $character->delete();
-
 
         $this->assertDatabaseCount(Entry::class, 3);
         Entry::all()->each(function ($entry) {


### PR DESCRIPTION
## Description
Closes #265 
Attempting to delete a character (or a user), raised an integrity constraint violation exception. This was because the character in question still had items, and ratings attached to their entries that were marked for deletion. 
This is solved by adding an observer that instead detaches entries from a character, leaving all the items and entries in tact. 

This approach prevents ratings or traded items from being deleted when a character is removed. 

Additionally soft deletes on users was added. The reasons are 2 fold: 
- Allows for users to be "banned"
- Allows a user to close their account without tossing away ratings and items they've created on the site.

Also adds a "default" account for ease of testing purposes. This account is automatically an admin. The credentials for this account are always `default@test.com` / `password`

## How to test
1. Migrate and seed your database
2. Login to an account with characters (See above example account)
3. Navigate to the character index
4. Pick a character and delete them
5. Observe that there is no error thrown
6. Open tinker (`php artisan tinker`)
7. Pick any user in the database (`$u = User::inRandomOrder()->first()`)
8. Observe their characters, entries, and items
9. Delete the user (`$u->delete()`)
10. Observe that their characters, entries, and items are still present in the database