### PR TITLE
GP inputs allow floats

### DIFF
--- a/resources/js/Components/Form/DmEntryCreateForm.tsx
+++ b/resources/js/Components/Form/DmEntryCreateForm.tsx
@@ -212,7 +212,12 @@ const DmEntryCreateForm = ({
                             },
                         }}
                         value={data.gp.toString()}
-                        onChange={(e) => setData('gp', parseInt(e.target.value))}
+                        onChange={(e) =>
+                            setData(
+                                'gp',
+                                parseFloat(parseFloat(e.target.value).toFixed(2)),
+                            )
+                        }
                     />
                     {errors?.gp && <ErrorText message={errors?.gp} />}
                 </StyledGrid>


### PR DESCRIPTION
Closes #266 
## Description
- GP input field in DMEntryCreateForm now accepts floats
-- Minimum is 0
-- Max 2 decimals
-- Values in TextField rounded up when input exceeds allowed number of decimals

## How to test 
Go to the DM Creation page and input a float format number into the GP text field.