### PR TITLE
Bulk entry delete

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -100,8 +100,9 @@ class CharacterController extends Controller
             // Foreach over all the characters so that we can check the policy against them.
             // Purposely not calling $characters->delete() here.
             foreach ($characters as $char) {
-                $user->can('delete', $char);
-                $char->delete();
+                if ($user->can('delete', $char)) {
+                    $char->delete();
+                }
             }
             return redirect()->route('character.index');
         }

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -154,9 +154,9 @@ class EntryController extends Controller
         if ($request->has('entries')) {
             $entries = Entry::whereIn('id', $data['entries'])->get();
 
-            foreach ($entries as $entry) {
-                if ($user->can('delete', $entry)) {
-                    $entry->delete();
+            foreach ($entries as $arrayEntry) {
+                if ($user->can('delete', $arrayEntry)) {
+                    $arrayEntry->delete();
                 }
             }
 

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -155,9 +155,11 @@ class EntryController extends Controller
             $entries = Entry::whereIn('id', $data['entries'])->get();
 
             foreach ($entries as $entry) {
-                $user->can('delete', $entry);
-                $entry->delete();
+                if ($user->can('delete', $entry)) {
+                    $entry->delete();
+                }
             }
+
             return redirect()->route('entry.index');
         }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,7 +37,10 @@ Route::middleware(['auth', 'throttle'])->group(function () {
 
     Route::resource('adventure', App\Http\Controllers\AdventureController::class);
 
-    Route::resource('entry', App\Http\Controllers\EntryController::class);
+    Route::delete('/entry/{entry?}', [App\Http\Controllers\EntryController::class, 'destroy'])
+        ->name("entry.destroy");
+
+    Route::resource('entry', App\Http\Controllers\EntryController::class)->except('destroy');
 
     Route::resource('entry-bulk', App\Http\Controllers\BulkEntryController::class)
         ->only(['store']);

--- a/tests/Feature/Http/Controllers/CharacterControllerTest.php
+++ b/tests/Feature/Http/Controllers/CharacterControllerTest.php
@@ -223,4 +223,22 @@ class CharacterControllerTest extends TestCase
 
         $this->assertDeleted($character);
     }
+
+    /**
+     * @test
+     */
+    public function destroy_deletes_in_bulk_and_redirects()
+    {
+        $characters = Character::factory(3)->create([
+            'user_id' => $this->user->id
+        ]);
+
+        $response = $this->delete(route('character.destroy', ['characters' => $characters->pluck('id')->toArray()]));
+
+        $response->assertRedirect(route('character.index'));
+
+        $this->assertDeleted($characters[0]);
+        $this->assertDeleted($characters[1]);
+        $this->assertDeleted($characters[2]);
+    }
 }

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -674,13 +674,34 @@ class EntryControllerTest extends TestCase
      */
     public function destroy_deletes_and_redirects()
     {
-        $entry = Entry::factory()->create();
+        $entry = Entry::factory()->create(['user_id' => $this->user->id]);
+        $user = $entry->user;
 
-        $response = $this->delete(route('entry.destroy', $entry));
+        $response = $this->actingAs($user)->delete(route('entry.destroy', $entry));
 
         $response->assertRedirect(route('entry.index'));
 
         $this->assertDeleted($entry);
+    }
+
+    /**
+     * @test
+     */
+    public function destroy_deletes_and_redirects_bulk()
+    {
+        $user = User::factory()->create();
+        $entries = Entry::factory(2)->create([
+            'user_id' => $user->id
+        ]);
+
+        $response = $this->actingAs($this->user)->delete(route('entry.destroy', [
+            'entries' => [$entries[0]->id, $entries[1]->id]
+        ]));
+
+        $response->assertRedirect(route('entry.index'));
+
+        $this->assertDeleted($entries[0]);
+        $this->assertDeleted($entries[1]);
     }
 
     /**
@@ -695,7 +716,6 @@ class EntryControllerTest extends TestCase
         $date_played = $this->faker->dateTime();
         $type = $this->faker->word;
 
-
         $ratingData = [
             "creative" => true,
             "flexible" => false,
@@ -703,8 +723,6 @@ class EntryControllerTest extends TestCase
             "helpful" => false,
             "prepared" => true
         ];
-
-
 
         $response = $this->actingAs($this->user)->post(route('entry.store'), [
             'user_id' => $this->user->id,

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -694,7 +694,7 @@ class EntryControllerTest extends TestCase
             'user_id' => $user->id
         ]);
 
-        $response = $this->actingAs($this->user)->delete(route('entry.destroy', [
+        $response = $this->actingAs($user)->delete(route('entry.destroy', [
             'entries' => [$entries[0]->id, $entries[1]->id]
         ]));
 

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -675,7 +675,7 @@ class EntryControllerTest extends TestCase
     public function destroy_deletes_and_redirects()
     {
         $entry = Entry::factory()->create(['user_id' => $this->user->id]);
-        $user = $entry->user;
+        $user = $this->user;
 
         $response = $this->actingAs($user)->delete(route('entry.destroy', $entry));
 


### PR DESCRIPTION
### Description
Closes #264  
Expands EntryController's destroy method to delete multiple entries passed as an array of entry IDs. 
Fixes bug in CharacterController's destroy method which allowed bulk character deletion by unauthorized user.

### How to Test
1. Create multiple entries with same user_id
2. Pass all entry ids as an array to destroy method
3. Check if specified entries have been successfully deleted from db
