### PR TITLE
Sort Entries by Date Played

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -69,9 +69,13 @@ class CharacterController extends Controller
             abort(403);
         }
 
-        $entries = $character->entries()->with('adventure', 'items', 'rating')->get();
+        $entries = $character
+            ->entries()
+            ->with('adventure', 'items', 'rating')
+            ->orderBy('date_played', 'desc')
+            ->get();
         $factions = array_values(Character::FACTIONS);
-      
+
 
         return Inertia::render('Character/Detail/CharacterDetail', compact('character', 'entries', 'factions'));
     }

--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -69,8 +69,7 @@ class CharacterController extends Controller
             abort(403);
         }
 
-        $entries = $character
-            ->entries()
+        $entries = $character->entries()
             ->with('adventure', 'items', 'rating')
             ->orderBy('date_played', 'desc')
             ->get();

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -117,18 +117,20 @@ class Entry extends Model
 
     public function getRewardAttribute()
     {
+        if ($this->type != self::TYPE_DM) {
+            return null;
+        }
+
         if (is_null($this->character_id)) {
             return "-";
         }
 
-        if ($this->type == self::TYPE_DM) {
-            if ($this->levels >= 1) {
-                return self::REWARD_ADVANCEMENT;
-            } elseif ($this->items()->count() >= 1) {
-                return self::REWARD_MAGIC_ITEM;
-            }
-
-            return self::REWARD_CAMPAIGN;
+        if ($this->levels >= 1) {
+            return self::REWARD_ADVANCEMENT;
+        } elseif ($this->items()->count() >= 1) {
+            return self::REWARD_MAGIC_ITEM;
         }
+
+        return self::REWARD_CAMPAIGN;
     }
 }

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -110,7 +110,7 @@ class Entry extends Model
         // refactor to scope query?
         return self::where('character_id', $this->character_id)
             ->where('adventure_id', $this->adventure_id)
-            ->where('date_played', ">", $this->date_played)
+            ->where('date_played', "<", $this->date_played)
             ->where('dungeon_master_id', $this->dungeon_master_id)
             ->count() + 1;
     }

--- a/tests/Unit/Models/EntryTest.php
+++ b/tests/Unit/Models/EntryTest.php
@@ -119,13 +119,14 @@ class EntryTest extends TestCase
             'author_id' => $character->user->id,
         ]);
         $campaign = Entry::factory()->create($defaults);
+        $nonDM = Entry::factory()->create([
+            'type' => Entry::TYPE_GAME
+        ]);
 
-        $isAdvancement = $advancement->reward == Entry::REWARD_ADVANCEMENT;
-        $isMagicItem = $magicItem->reward == Entry::REWARD_MAGIC_ITEM;
-        $isCampaign = $campaign->reward == Entry::REWARD_CAMPAIGN;
 
-        $this->assertTrue($isAdvancement);
-        $this->assertTrue($isMagicItem);
-        $this->assertTrue($isCampaign);
+        $this->assertEquals(Entry::REWARD_ADVANCEMENT, $advancement->reward);
+        $this->assertEquals(Entry::REWARD_MAGIC_ITEM, $magicItem->reward);
+        $this->assertEquals(Entry::REWARD_CAMPAIGN, $campaign->reward);
+        $this->assertNull($nonDM->reward);
     }
 }


### PR DESCRIPTION
## Description
Closes #296 

Adds proper sorting to lines in entry table. Lines are now sorted by `date_played` in reverse chronological order. Additionally counter for session now counts in the proper direction, labelling the oldest game as "1" and the newest game as "n" where n is the number of games played in 1 adventure.

## How to test
1. Login to an account with multiple entries for a character (preferably one with the same adventure across at least 2 entries)
2. Navigate to the Character's detail page
3. Observe that the entries are dated from newest to oldest.
4. Observe that the session attribute is also in descending order