### PR TITLE
Magic items column missing from DM entries table and entries table

### DIFF
--- a/app/Http/Controllers/DMEntryController.php
+++ b/app/Http/Controllers/DMEntryController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\EntryStoreRequest;
 use App\Models\Adventure;
 use App\Models\Entry;
 use App\Models\Character;
+use App\Models\Item;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
@@ -20,7 +21,7 @@ class DMEntryController extends Controller
     {
         $entries = Entry::where('type', Entry::TYPE_DM)
             ->where('user_id', Auth::id())
-            ->with('character', 'adventure')
+            ->with('character', 'adventure', 'items')
             ->get();
 
         return Inertia::render('DMEntry/DMEntry', compact('entries'));

--- a/resources/js/Components/Table/DMEntryTable/DMEntryTable.tsx
+++ b/resources/js/Components/Table/DMEntryTable/DMEntryTable.tsx
@@ -22,6 +22,8 @@ const DMEntryTable = ({data}: DMEntryPropType) => {
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false)
     const {setData, delete: destroy} = useForm<FormDataType>({entries: []})
 
+    const itemFormatter = (items: any[]) => items.map((item: any) => item.name).join(', ')
+
     const leftActions = [
         <Link href={route('dm-entry.create')}>
             <Button variant='contained' startIcon={<HistoryEduIcon />}>
@@ -59,8 +61,9 @@ const DMEntryTable = ({data}: DMEntryPropType) => {
             title: 'Reward',
         },
         {
-            property: null,
+            property: 'items',
             title: 'Magic Items',
+            render: (value: any) => itemFormatter(value),
         },
         {
             property: null,

--- a/resources/js/Components/Table/DMEntryTable/DMEntryTable.tsx
+++ b/resources/js/Components/Table/DMEntryTable/DMEntryTable.tsx
@@ -7,6 +7,7 @@ import {DataTable, DeleteModal, Link} from 'Components'
 import dayjs from 'dayjs'
 import React, {useState} from 'react'
 import {EntriesData} from 'Types/entries-data'
+import {itemFormatter} from 'Utils'
 import route from 'ziggy-js'
 
 type DMEntryPropType = {
@@ -21,8 +22,6 @@ const DMEntryTable = ({data}: DMEntryPropType) => {
     const [selected, setSelected] = useState<number[]>([])
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false)
     const {setData, delete: destroy} = useForm<FormDataType>({entries: []})
-
-    const itemFormatter = (items: any[]) => items.map((item: any) => item.name).join(', ')
 
     const leftActions = [
         <Link href={route('dm-entry.create')}>

--- a/resources/js/Components/Table/EntryTable/EntryTable.tsx
+++ b/resources/js/Components/Table/EntryTable/EntryTable.tsx
@@ -6,6 +6,7 @@ import {DataTable, DeleteModal} from 'Components'
 import dayjs from 'dayjs'
 import React, {useState} from 'react'
 import {EntriesData} from 'Types/entries-data'
+import {itemFormatter} from 'Utils'
 import route from 'ziggy-js'
 
 type EntryPropType = {
@@ -45,11 +46,9 @@ const EntryTable = ({data}: EntryPropType) => {
             title: 'Reward',
         },
         {
-            property: 'items.name',
+            property: 'items',
             title: 'Magic Items',
-            render: (value: any) => (
-                <Chip aria-label='item' label={value.items.name} variant='outlined' />
-            ),
+            render: (value: any) => itemFormatter(value),
         },
         {
             property: null,

--- a/resources/js/Utils/formatter.ts
+++ b/resources/js/Utils/formatter.ts
@@ -1,0 +1,2 @@
+export const itemFormatter = (items: any[]) =>
+    items.map((item: any) => item.name).join(', ')

--- a/resources/js/Utils/index.ts
+++ b/resources/js/Utils/index.ts
@@ -1,3 +1,4 @@
+export {itemFormatter} from './formatter'
 export {EMAIL_VALIDATION_REGEX} from './regex'
 export {DEFAULT_PAGE, DEFAULT_ROWS_PER_PAGE} from './table-constant'
 export {getFontTheme} from './theme'


### PR DESCRIPTION
closes #273 

## Description
- Add missing magic items that were not showing in the 'Magic Items' column in the DM entries table and in the entries table