### PR TITLE
Add Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,12 @@
+name: Deploy Production
+
+on:
+  release:
+    types: [published]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Deploy Url
+        run: curl ${{ secrets.DEPLOY_TRIGGER }}


### PR DESCRIPTION
## Description
Closes #227 
Adds a Github Action which triggers on the publish of a new release. 

When Published, The action simply triggers a deployment on the Production server via a deployment trigger URL.

