### PR TITLE
Implement DateTime picker for Entry and DMEntry forms

### DIFF
--- a/resources/js/Components/Form/DmEntryCreateForm.tsx
+++ b/resources/js/Components/Form/DmEntryCreateForm.tsx
@@ -1,6 +1,6 @@
 import {useForm} from '@inertiajs/inertia-react'
 import AdapterDateFns from '@mui/lab/AdapterDateFns'
-import DatePicker from '@mui/lab/DatePicker'
+import DateTimePicker from '@mui/lab/DateTimePicker'
 import LocalizationProvider from '@mui/lab/LocalizationProvider'
 import {Button, Grid, TextField, Typography} from '@mui/material'
 import useUser from '@Utils/use-user'
@@ -197,10 +197,9 @@ const DmEntryCreateForm = ({
             </StyledGrid>
             <StyledGrid item xs={12} md={type === 'Edit' ? 12 : 2}>
                 <LocalizationProvider dateAdapter={AdapterDateFns}>
-                    <DatePicker
+                    <DateTimePicker
                         label='Date'
                         value={data.date_played}
-                        inputFormat='yyyy-MM-dd'
                         onChange={(e) => {
                             setData('date_played', e)
                         }}

--- a/resources/js/Components/Form/EntryCreateForm.tsx
+++ b/resources/js/Components/Form/EntryCreateForm.tsx
@@ -1,6 +1,6 @@
 import {useForm} from '@inertiajs/inertia-react'
 import AdapterDateFns from '@mui/lab/AdapterDateFns'
-import DatePicker from '@mui/lab/DatePicker'
+import DateTimePicker from '@mui/lab/DateTimePicker'
 import LocalizationProvider from '@mui/lab/LocalizationProvider'
 import {Button, Grid, TextField, Typography} from '@mui/material'
 import useUser from '@Utils/use-user'
@@ -199,10 +199,9 @@ const EntryCreateForm = ({
             </StyledGrid>
             <StyledGrid item xs={12} md={type === 'Edit' ? 12 : 2}>
                 <LocalizationProvider dateAdapter={AdapterDateFns}>
-                    <DatePicker
+                    <DateTimePicker
                         label='Date'
                         value={data.date_played}
-                        inputFormat='yyyy-MM-dd'
                         onChange={(e) => {
                             setData('date_played', e)
                         }}

--- a/resources/js/Components/Table/DMEntryTable/DMEntryTable.tsx
+++ b/resources/js/Components/Table/DMEntryTable/DMEntryTable.tsx
@@ -30,7 +30,6 @@ const DMEntryTable = ({
     const [selected, setSelected] = useState<number[]>([])
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false)
     const {setData, delete: destroy} = useForm<FormDataType>({entries: []})
-
     const leftActions = [
         <Link href={route('dm-entry.create')}>
             <Button variant='contained' startIcon={<HistoryEduIcon />}>
@@ -38,13 +37,13 @@ const DMEntryTable = ({
             </Button>
         </Link>,
     ]
-
+    console.log(data[0].date_played)
     const columns = [
         {
             property: 'date_played',
             title: 'Date',
             render: (value: string) => (
-                <Typography>{dayjs(value).format('YYYY-MM-DD HH:MM')}</Typography>
+                <Typography>{dayjs(value).format('YYYY-MM-DD HH:mm')}</Typography>
             ),
         },
         {

--- a/resources/js/Components/Table/DMEntryTable/DMEntryTable.tsx
+++ b/resources/js/Components/Table/DMEntryTable/DMEntryTable.tsx
@@ -37,7 +37,6 @@ const DMEntryTable = ({
             </Button>
         </Link>,
     ]
-    console.log(data[0].date_played)
     const columns = [
         {
             property: 'date_played',

--- a/resources/js/Components/Table/EntryTable/EntryTable.tsx
+++ b/resources/js/Components/Table/EntryTable/EntryTable.tsx
@@ -35,7 +35,7 @@ const EntryTable = ({
             property: 'date_played',
             title: 'Date',
             render: (value: string) => (
-                <Typography>{dayjs(value).format('YYYY-MM-DD HH:MM')}</Typography>
+                <Typography>{dayjs(value).format('YYYY-MM-DD HH:mm')}</Typography>
             ),
         },
         {


### PR DESCRIPTION
Closes #286 

# Description
- MUI's Date&Time picker used to replace the Date input fields
- Character entries and DM entries now have a date and time precision
- Entry tables now show correct time

# How to test
1. Create an entry form and assign a date and time
2. Verify date/time selected for said entry
 
