### PR TITLE
Trade Detail Response

### DIFF
--- a/app/Http/Controllers/TradeController.php
+++ b/app/Http/Controllers/TradeController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\TradeStoreRequest;
 use App\Http\Requests\TradeUpdateRequest;
 use App\Models\Trade;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class TradeController extends Controller
 {
@@ -49,7 +50,15 @@ class TradeController extends Controller
      */
     public function show(Request $request, Trade $trade)
     {
-        return view('trade.show', compact('trade'));
+        $currentUserID = Auth::user()->id;
+        $tradeItem = $trade->item;
+        $tradeCharacter = $trade->character;
+
+        if ($currentUserID == $trade->user->id) {
+            $tradeOffers = $trade->items()->with('character');
+            return view('trade.show', compact('trade', 'tradeItem', 'tradeCharacter', 'tradeOffers'));
+        }
+        return view('trade.show', compact('trade', 'tradeItem', 'tradeCharacter'));
     }
 
     /**

--- a/app/Http/Controllers/TradeController.php
+++ b/app/Http/Controllers/TradeController.php
@@ -54,7 +54,7 @@ class TradeController extends Controller
         $tradeItem = $trade->item;
         $tradeCharacter = $trade->character;
 
-        if ($currentUserID == $trade->user->id) {
+        if ($currentUserID == $tradeCharacter->user->id) {
             $tradeOffers = $trade->items()->with('character');
             return view('trade.show', compact('trade', 'tradeItem', 'tradeCharacter', 'tradeOffers'));
         }

--- a/tests/Feature/Http/Controllers/TradeControllerTest.php
+++ b/tests/Feature/Http/Controllers/TradeControllerTest.php
@@ -108,6 +108,8 @@ class TradeControllerTest extends TestCase
      */
     public function show_displays_view()
     {
+        $tradeRouteString = 'trade.show';
+
         $someUser = User::factory()->create();
         $character = Character::factory()->create(["user_id" => $someUser->id]);
         $item = Item::factory()->create(["character_id" => $character->id]);
@@ -115,20 +117,20 @@ class TradeControllerTest extends TestCase
             "character_id" => $character->id,
             "item_id" => $item->id]);
 
-        $response = $this->get(route('trade.show', $trade));
+        $response = $this->get(route($tradeRouteString, $trade));
 
         $response->assertOk();
-        $response->assertViewIs('trade.show');
+        $response->assertViewIs($tradeRouteString);
         $response->assertViewHas('trade');
         $response->assertViewHas('tradeItem');
         $response->assertViewHas('tradeCharacter');
         $response->assertViewMissing('tradeOffers');
 
         $character->user()->associate($this->user)->save();
-        $response = $this->get(route('trade.show', $trade));
+        $response = $this->get(route($tradeRouteString, $trade));
 
         $response->assertOk();
-        $response->assertViewIs('trade.show');
+        $response->assertViewIs($tradeRouteString);
         $response->assertViewHas('trade');
         $response->assertViewHas('tradeItem');
         $response->assertViewHas('tradeCharacter');

--- a/tests/Feature/Http/Controllers/TradeControllerTest.php
+++ b/tests/Feature/Http/Controllers/TradeControllerTest.php
@@ -108,13 +108,31 @@ class TradeControllerTest extends TestCase
      */
     public function show_displays_view()
     {
-        $trade = Trade::factory()->create();
+        $someUser = User::factory()->create();
+        $character = Character::factory()->create(["user_id" => $someUser->id]);
+        $item = Item::factory()->create(["character_id" => $character->id]);
+        $trade = Trade::factory()->create([
+            "character_id" => $character->id,
+            "item_id" => $item->id]);
 
         $response = $this->get(route('trade.show', $trade));
 
         $response->assertOk();
         $response->assertViewIs('trade.show');
         $response->assertViewHas('trade');
+        $response->assertViewHas('tradeItem');
+        $response->assertViewHas('tradeCharacter');
+        $response->assertViewMissing('tradeOffers');
+
+        $character->user()->associate($this->user)->save();
+        $response = $this->get(route('trade.show', $trade));
+
+        $response->assertOk();
+        $response->assertViewIs('trade.show');
+        $response->assertViewHas('trade');
+        $response->assertViewHas('tradeItem');
+        $response->assertViewHas('tradeCharacter');
+        $response->assertViewHas('tradeOffers');
     }
 
 


### PR DESCRIPTION
## Description
Closes #377 
Modifies the TradeController's show endpoint to return more data. Also, data returned depends on if the current user is the creator of the given trade or not.

If they are not, they are only shown the character, user, and trade item info. This allows the user to view the character and item that pertain to the trade.

If they are, they are shown the above info as well as offers that have been made against their trade. These offers come in the for of items with their associated character loaded as well, so that the user can audit the character.