### PR TITLE
Rating step skipped when the gm field is empty

### DIFF
--- a/resources/js/Components/Form/EntryCreateForm.tsx
+++ b/resources/js/Components/Form/EntryCreateForm.tsx
@@ -306,23 +306,15 @@ const EntryCreateForm = ({
     const stepThreeFooter = (
         <StyledGrid container spacing={4}>
             <Grid item xs={4}>
-                {data.dungeon_master === '' ? (
-                    <Button
-                        fullWidth
-                        onClick={() =>
-                            type === 'Create' ? setActiveStep(0) : setActiveStep(0)
-                        }>
-                        Previous
-                    </Button>
-                ) : (
-                    <Button
-                        fullWidth
-                        onClick={() =>
-                            type === 'Create' ? setActiveStep(1) : setActiveStep(0)
-                        }>
-                        Previous
-                    </Button>
-                )}
+                <Button
+                    fullWidth
+                    onClick={() =>
+                        type === 'Edit' || data.dungeon_master === ''
+                            ? setActiveStep(0)
+                            : setActiveStep(1)
+                    }>
+                    Previous
+                </Button>
             </Grid>
             <Grid item xs={4} />
             <Grid item xs={4}>

--- a/resources/js/Components/Form/EntryCreateForm.tsx
+++ b/resources/js/Components/Form/EntryCreateForm.tsx
@@ -268,7 +268,9 @@ const EntryCreateForm = ({
                 <Button
                     variant='contained'
                     onClick={() =>
-                        data.dungeon_master === '' ? setActiveStep(2) : setActiveStep(1)
+                        type === 'Create' && !data.dungeon_master
+                            ? setActiveStep(2)
+                            : setActiveStep(1)
                     }
                     fullWidth>
                     Continue

--- a/resources/js/Components/Form/EntryCreateForm.tsx
+++ b/resources/js/Components/Form/EntryCreateForm.tsx
@@ -265,21 +265,14 @@ const EntryCreateForm = ({
             </Grid>
             <Grid item xs={4} />
             <Grid item xs={4}>
-                {data.dungeon_master === '' ? (
-                    <Button
-                        variant='contained'
-                        onClick={() => setActiveStep(2)}
-                        fullWidth>
-                        Continue
-                    </Button>
-                ) : (
-                    <Button
-                        variant='contained'
-                        onClick={() => setActiveStep(1)}
-                        fullWidth>
-                        Continue
-                    </Button>
-                )}
+                <Button
+                    variant='contained'
+                    onClick={() =>
+                        data.dungeon_master === '' ? setActiveStep(2) : setActiveStep(1)
+                    }
+                    fullWidth>
+                    Continue
+                </Button>
             </Grid>
         </StyledGrid>
     )
@@ -314,7 +307,11 @@ const EntryCreateForm = ({
         <StyledGrid container spacing={4}>
             <Grid item xs={4}>
                 {data.dungeon_master === '' ? (
-                    <Button fullWidth onClick={() => setActiveStep(0)}>
+                    <Button
+                        fullWidth
+                        onClick={() =>
+                            type === 'Create' ? setActiveStep(0) : setActiveStep(0)
+                        }>
                         Previous
                     </Button>
                 ) : (

--- a/resources/js/Components/Form/EntryCreateForm.tsx
+++ b/resources/js/Components/Form/EntryCreateForm.tsx
@@ -265,9 +265,21 @@ const EntryCreateForm = ({
             </Grid>
             <Grid item xs={4} />
             <Grid item xs={4}>
-                <Button variant='contained' onClick={() => setActiveStep(1)} fullWidth>
-                    Continue
-                </Button>
+                {data.dungeon_master === '' ? (
+                    <Button
+                        variant='contained'
+                        onClick={() => setActiveStep(2)}
+                        fullWidth>
+                        Continue
+                    </Button>
+                ) : (
+                    <Button
+                        variant='contained'
+                        onClick={() => setActiveStep(1)}
+                        fullWidth>
+                        Continue
+                    </Button>
+                )}
             </Grid>
         </StyledGrid>
     )
@@ -301,13 +313,19 @@ const EntryCreateForm = ({
     const stepThreeFooter = (
         <StyledGrid container spacing={4}>
             <Grid item xs={4}>
-                <Button
-                    fullWidth
-                    onClick={() =>
-                        type === 'Create' ? setActiveStep(1) : setActiveStep(0)
-                    }>
-                    Previous
-                </Button>
+                {data.dungeon_master === '' ? (
+                    <Button fullWidth onClick={() => setActiveStep(0)}>
+                        Previous
+                    </Button>
+                ) : (
+                    <Button
+                        fullWidth
+                        onClick={() =>
+                            type === 'Create' ? setActiveStep(1) : setActiveStep(0)
+                        }>
+                        Previous
+                    </Button>
+                )}
             </Grid>
             <Grid item xs={4} />
             <Grid item xs={4}>

--- a/resources/js/Components/Form/EntryCreateForm.tsx
+++ b/resources/js/Components/Form/EntryCreateForm.tsx
@@ -311,7 +311,7 @@ const EntryCreateForm = ({
                 <Button
                     fullWidth
                     onClick={() =>
-                        type === 'Edit' || data.dungeon_master === ''
+                        type === 'Edit' || !data.dungeon_master
                             ? setActiveStep(0)
                             : setActiveStep(1)
                     }>


### PR DESCRIPTION
Closes #308 

If GM field is empty
- When clicking continue on the first step of Entry form, skips to 3rd step.
- From the 3rd step, when clicking previous, goes back to first step.