### PR TITLE
Change Entry Update to no longer delete existing items

### DIFF
--- a/app/Actions/CreateEntryItems.php
+++ b/app/Actions/CreateEntryItems.php
@@ -20,16 +20,25 @@ class CreateEntryItems
     public function handle(Entry $entry, array $items)
     {
         $out = collect();
-
-        $entry->items()->delete();
+        $items = collect($items)->sortBy('id');
+        $existing = Item::whereIn('id', $items->pluck('id')->filter())
+            ->where('character_id', $entry->character_id)
+            ->get()
+            ->getDictionary();
 
         foreach ($items as $item) {
-            $out[] = new Item(
-                array_merge([
-                    'author_id' => Auth::id(),
-                    'character_id' => $entry->character_id
-                ], $item)
-            );
+            // if the item exists, update it
+            if (isset($item['id'])) {
+                $out[] = $existing[$item['id']]->fill($item);
+            } else {
+                // otherwise, make a new one
+                $out[] = new Item(
+                    array_merge([
+                        'author_id' => Auth::id(),
+                        'character_id' => $entry->character_id
+                    ], $item)
+                );
+            }
         }
 
         return $entry->items()->saveMany($out);

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -154,7 +154,7 @@ class EntryController extends Controller
             $itemData = $itemData->toArray();
         }
 
-        list($entryData, $itemData) = $this->chooseReward($entryData, $itemData);
+        list($entryData, $itemData) = $this->chooseReward($entryData, $itemData, $entry);
 
         // Attempt to find the DM based on the name passed
         if ((empty($entryData['dungeon_master_id']) || !$entry->dungeon_master_id) && $entryData['type'] !== Entry::TYPE_DM) {
@@ -215,7 +215,7 @@ class EntryController extends Controller
      * @param array $itemData
      * @return array
      */
-    private function chooseReward(Collection $entryData, array $itemData): array
+    private function chooseReward(Collection $entryData, array $itemData, Entry $entry = null): array
     {
         if ($entryData->get('choice') == 'advancement') {
             // advancement: increment character's level
@@ -227,6 +227,9 @@ class EntryController extends Controller
             $entryData['levels'] = 0;
         } elseif ($entryData->get('choice') == 'campaign_reward') {
             // campaign reward: set levels = 0, no item(s), should contain custom note
+            if ($entry) {
+                $entry->items()->delete();
+            }
             $itemData = [];
             $entryData['levels'] = 0;
         }

--- a/app/Http/Requests/EntryStoreRequest.php
+++ b/app/Http/Requests/EntryStoreRequest.php
@@ -6,6 +6,7 @@ use App\Models\Character;
 use App\Models\Entry;
 use App\Models\Item;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 
 class EntryStoreRequest extends FormRequest
@@ -18,7 +19,7 @@ class EntryStoreRequest extends FormRequest
     public function authorize()
     {
         if (is_null($this->character_id)) {
-            return $this->type == Entry::TYPE_DM;
+            return $this->type == Entry::TYPE_DM && $this->user_id == Auth::id();
         }
         $character = Character::findOrFail($this->character_id);
         return $this->user()->can('update', $character);

--- a/app/Http/Requests/EntryUpdateRequest.php
+++ b/app/Http/Requests/EntryUpdateRequest.php
@@ -18,7 +18,7 @@ class EntryUpdateRequest extends FormRequest
     public function authorize()
     {
         if (is_null($this->character_id)) {
-            return $this->type == Entry::TYPE_DM;
+            return $this->type == Entry::TYPE_DM && $this->user()->can('update', $this->entry);
         }
 
         return $this->user()->can('update', Character::findOrFail($this->character_id))  && $this->user()->can('update', $this->entry);
@@ -50,6 +50,7 @@ class EntryUpdateRequest extends FormRequest
             'downtime' => ['sometimes', 'integer'],
             'notes' => ['nullable', 'string'],
             'items' => ['sometimes', 'array'],
+            'items.*.id' => ['sometimes', 'integer', 'exists:items,id'],
             'items.*.name' => ['string', $requiredIf],
             'items.*.rarity' => ["in:{$rarities}", $requiredIf],
             'items.*.tier' =>  ['integer', 'between:1,4', $requiredIf],

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -675,6 +675,7 @@ class EntryControllerTest extends TestCase
 
         $entry = Entry::factory()->create([
             'type' => Entry::TYPE_DM,
+            'user_id' => $this->user->id
         ]);
 
         $character->user()->associate($this->user)->save();
@@ -750,6 +751,7 @@ class EntryControllerTest extends TestCase
         $entry = Entry::factory()->create([
             'type' => Entry::TYPE_DM,
             'levels' => 5,
+            'user_id' => $this->user->id
         ]);
 
         $character->user()->associate($this->user)->save();
@@ -779,7 +781,6 @@ class EntryControllerTest extends TestCase
             'gp' => $gp,
             'choice' => 'campaign_reward',
         ]);
-
         $character->refresh();
 
         $this->assertEquals(0, $character->levels);


### PR DESCRIPTION
## Description
Closes #381
Changes the Entry update endpoint account for existing items. Achieves this by loading items that already exist and opting to update them rather than deleting all items and then re-creating them.

