### PR TITLE
Session Overlap Check

### DIFF
--- a/app/Http/Controllers/Admin/SessionCrudController.php
+++ b/app/Http/Controllers/Admin/SessionCrudController.php
@@ -44,6 +44,7 @@ class SessionCrudController extends CrudController
         CRUD::column('dungeonMaster');
         CRUD::column('table');
         CRUD::column('start_time');
+        CRUD::column('end_time');
     }
 
     /**
@@ -61,6 +62,7 @@ class SessionCrudController extends CrudController
         CRUD::field('dungeonMaster');
         CRUD::field('table');
         CRUD::field('start_time');
+        CRUD::field('end_time');
     }
 
     /**

--- a/app/Http/Controllers/EventRegistrationController.php
+++ b/app/Http/Controllers/EventRegistrationController.php
@@ -45,7 +45,10 @@ class EventRegistrationController extends Controller
             ->orWhereHas('dungeonMaster', function ($q) use ($userId) {
                 $q->where('user_id', $userId);
             })
-            ->where('start_date', '>', now());
+            ->where('start_date', '>', now())
+            ->get();
+
+        dump($userSessions);
 
         if (!isset($data['session_id'])) {
             // if they're not choosing a specific session, just register them to an open table with seats

--- a/app/Http/Controllers/EventRegistrationController.php
+++ b/app/Http/Controllers/EventRegistrationController.php
@@ -35,7 +35,6 @@ class EventRegistrationController extends Controller
             $q->where('id', $userId);
         })->get();
 
-
         if (!isset($data['session_id'])) {
             // if they're not choosing a specific session, just register them to an open table with seats
             $session = Session::hasOpenSeats($data['event_id'])

--- a/app/Http/Controllers/EventRegistrationController.php
+++ b/app/Http/Controllers/EventRegistrationController.php
@@ -29,26 +29,12 @@ class EventRegistrationController extends Controller
 
         $userId = Auth::id();
 
-        /*
-        Get all sessions that the current user is involved in as either a player or a game master
-        =====================================================================================
-        The final where statement is there to reduce the amount of sessions in the query result
-        thus improving performance, however it potentially introduces an edge case
-        where the user can register for a session s1 which overlaps with a session s2 when
-        s2 is already in progress and the user is involved in s2.
-        If the edge case becomes an issue, remove the final where clause.
-        Keep in mind that removing it may result in a loss of performance
-        */
         $userSessions = Session::whereHas('characters', function ($q) use ($userId) {
             $q->where('user_id', $userId);
-        })
-            ->orWhereHas('dungeonMaster', function ($q) use ($userId) {
-                $q->where('user_id', $userId);
-            })
-            ->where('start_date', '>', now())
-            ->get();
+        })->orWhereHas('dungeonMaster', function ($q) use ($userId) {
+            $q->where('id', $userId);
+        })->get();
 
-        dump($userSessions);
 
         if (!isset($data['session_id'])) {
             // if they're not choosing a specific session, just register them to an open table with seats

--- a/app/Http/Controllers/EventRegistrationController.php
+++ b/app/Http/Controllers/EventRegistrationController.php
@@ -7,6 +7,7 @@ use App\Models\Character;
 use App\Models\Event;
 use App\Models\Session;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\UnauthorizedException;
 use Inertia\Inertia;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
@@ -26,6 +27,26 @@ class EventRegistrationController extends Controller
 
         $character = Character::find($data['character_id']);
 
+        $userId = Auth::id();
+
+        /*
+        Get all sessions that the current user is involved in as either a player or a game master
+        =====================================================================================
+        The final where statement is there to reduce the amount of sessions in the query result
+        thus improving performance, however it potentially introduces an edge case
+        where the user can register for a session s1 which overlaps with a session s2 when
+        s2 is already in progress and the user is involved in s2.
+        If the edge case becomes an issue, remove the final where clause.
+        Keep in mind that removing it may result in a loss of performance
+        */
+        $userSessions = Session::whereHas('characters', function ($q) use ($userId) {
+            $q->where('user_id', $userId);
+        })
+            ->orWhereHas('dungeonMaster', function ($q) use ($userId) {
+                $q->where('user_id', $userId);
+            })
+            ->where('start_date', '>', now());
+
         if (!isset($data['session_id'])) {
             // if they're not choosing a specific session, just register them to an open table with seats
             $session = Session::hasOpenSeats($data['event_id'])
@@ -39,6 +60,14 @@ class EventRegistrationController extends Controller
             return back()->withErrors([
                 'seats' => "There are not enough open seats for you to register!"
             ]);
+        }
+
+        foreach ($userSessions as $userSession) {
+            if ($session->overlapsWith($userSession)) {
+                return back()->withErrors([
+                    'overlap' => "The session you have attempted to register for overlaps with one you are currently registered in."
+                ]);
+            }
         }
 
         $character->sessions()->attach($session);

--- a/app/Http/Requests/SessionStoreRequest.php
+++ b/app/Http/Requests/SessionStoreRequest.php
@@ -29,6 +29,7 @@ class SessionStoreRequest extends FormRequest
             'dungeon_master_id' => ['required', 'integer', 'exists:users,id'],
             'table' => ['required', 'string'],
             'start_time' => ['required'],
+            'end_time' => ['required'],
         ];
     }
 }

--- a/app/Http/Requests/SessionUpdateRequest.php
+++ b/app/Http/Requests/SessionUpdateRequest.php
@@ -29,6 +29,7 @@ class SessionUpdateRequest extends FormRequest
             'dungeon_master_id' => ['required', 'integer', 'exists:users,id'],
             'table' => ['required', 'string'],
             'start_time' => ['required'],
+            'end_time' => ['required'],
         ];
     }
 }

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -103,8 +103,8 @@ class Session extends Model
         $startTime = $this->start_time;
         $endTime= $this->end_time;
 
-        $startsWithin = $startTime < $otherSessionStart && $otherSessionStart < $endTime;
-        $endsWithin = $startTime < $otherSessionEnd && $otherSessionEnd < $endTime;
+        $startsWithin = $startTime <= $otherSessionStart && $otherSessionStart <= $endTime;
+        $endsWithin = $startTime <= $otherSessionEnd && $otherSessionEnd <= $endTime;
 
         return $startsWithin || $endsWithin;
     }

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -86,5 +87,25 @@ class Session extends Model
 
         return $q->withCount('characters')
             ->having('characters_count', "<", DB::raw('seats'));
+    }
+
+    /**
+     * Determines if this session overlaps with the given session
+     * @param Session $otherSession
+     * @return bool true if overlapping
+     */
+
+    public function overlapsWith(Session $otherSession): bool
+    {
+        $otherSessionStart = $otherSession->start_time;
+        $otherSessionEnd = $otherSession->end_time;
+
+        $startTime = $this->start_time;
+        $endTime= $this->end_time;
+
+        $startsWithin = $startTime < $otherSessionStart && $otherSessionStart < $endTime;
+        $endsWithin = $startTime < $otherSessionEnd && $otherSessionEnd < $endTime;
+
+        return $startsWithin || $endsWithin;
     }
 }

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -23,6 +23,7 @@ class Session extends Model
         'dungeon_master_id',
         'table',
         'start_time',
+        'end_time',
         'language',
     ];
 
@@ -37,6 +38,7 @@ class Session extends Model
         'adventure_id' => 'integer',
         'dungeon_master_id' => 'integer',
         'start_time' => 'datetime',
+        'end_time' => 'datetime',
     ];
 
     protected $with = ['event'];

--- a/database/factories/SessionFactory.php
+++ b/database/factories/SessionFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use App\Models\Adventure;
@@ -25,13 +26,16 @@ class SessionFactory extends Factory
      */
     public function definition()
     {
+        $startTime = $this->faker->dateTime();
+
         return [
             'event_id' => Event::factory(),
             'adventure_id' => Adventure::factory(),
             'dungeon_master_id' => User::factory(),
             'table' => $this->faker->randomDigit()+1,
             'seats' => $this->faker->numberBetween(2, 8),
-            'start_time' => $this->faker->dateTime(),
+            'start_time' => $startTime,
+            'end_time' => $this->faker->dateTimeBetween($startTime, $endDate = 'now'),
             'language' => $this->faker->randomElement(["FR","EN"]),
         ];
     }

--- a/database/migrations/2022_02_26_215017_add_end_time_to_sessions_table.php
+++ b/database/migrations/2022_02_26_215017_add_end_time_to_sessions_table.php
@@ -14,7 +14,7 @@ class AddEndTimeToSessionsTable extends Migration
     public function up()
     {
         Schema::table('sessions', function (Blueprint $table) {
-            $table->timestamp('end_time');
+            $table->timestamp('end_time')->nullable();
         });
     }
 

--- a/database/migrations/2022_02_26_215017_add_end_time_to_sessions_table.php
+++ b/database/migrations/2022_02_26_215017_add_end_time_to_sessions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEndTimeToSessionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->timestamp('end_time');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->dropColumn('end_time');
+        });
+    }
+}

--- a/tests/Feature/Http/Controllers/EventRegistrationControllerTest.php
+++ b/tests/Feature/Http/Controllers/EventRegistrationControllerTest.php
@@ -6,6 +6,7 @@ use App\Models\Character;
 use App\Models\Event;
 use App\Models\Session;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Auth;
@@ -62,6 +63,37 @@ class EventRegistrationControllerTest extends TestCase
 
         $response = $this->post(route('registration.store', [
             'session_id' => $fullEvent->sessions[0]->id,
+            'character_id' => $character->id
+        ]));
+
+        $response->assertRedirect();
+        $response->assertSessionHasErrors();
+    }
+
+    /**
+     * @test
+     */
+    public function store_prevents_a_character_from_registering_for_overlapping_session()
+    {
+        $startTime = Carbon::now()->addHour();
+        $endTime = Carbon::now()->addHours(5);
+        $character = Character::factory()->create([
+            'user_id' => $this->user->id
+        ]);
+        $event = Event::factory()
+            ->has(Session::factory(2)->state([
+                'seats' => 3,
+                'start_time' => $startTime,
+                'end_time' => $endTime,
+            ]))->create();
+
+        $this->post(route('registration.store', [
+            'session_id' => $event->sessions[0]->id,
+            'character_id' => $character->id
+        ]));
+
+        $response = $this->post(route('registration.store', [
+            'session_id' => $event->sessions[1]->id,
             'character_id' => $character->id
         ]));
 

--- a/tests/Feature/Http/Controllers/SessionControllerTest.php
+++ b/tests/Feature/Http/Controllers/SessionControllerTest.php
@@ -79,6 +79,7 @@ class SessionControllerTest extends TestCase
         $dungeon_master = User::factory()->create();
         $table = $this->faker->word;
         $start_time = $this->faker->dateTime();
+        $end_time = $this->faker->dateTime();
 
         $response = $this->post(route('session.store'), [
             'event_id' => $event->id,
@@ -86,6 +87,7 @@ class SessionControllerTest extends TestCase
             'dungeon_master_id' => $dungeon_master->id,
             'table' => $table,
             'start_time' => $start_time,
+            'end_time' => $end_time,
         ]);
 
         $sessions = Session::query()
@@ -94,6 +96,7 @@ class SessionControllerTest extends TestCase
             ->where('dungeon_master_id', $dungeon_master->id)
             ->where('table', $table)
             ->where('start_time', $start_time)
+            ->where('end_time', $end_time)
             ->get();
         $this->assertCount(1, $sessions);
         $session = $sessions->first();
@@ -156,6 +159,7 @@ class SessionControllerTest extends TestCase
         $dungeon_master = User::factory()->create();
         $table = $this->faker->word;
         $start_time = $this->faker->dateTime();
+        $end_time = $this->faker->dateTime();
 
         $response = $this->put(route('session.update', $session), [
             'event_id' => $event->id,
@@ -163,6 +167,7 @@ class SessionControllerTest extends TestCase
             'dungeon_master_id' => $dungeon_master->id,
             'table' => $table,
             'start_time' => $start_time,
+            'end_time' => $end_time,
         ]);
 
         $session->refresh();
@@ -175,6 +180,7 @@ class SessionControllerTest extends TestCase
         $this->assertEquals($dungeon_master->id, $session->dungeon_master_id);
         $this->assertEquals($table, $session->table);
         $this->assertEquals($start_time, $session->start_time);
+        $this->assertEquals($end_time, $session->end_time);
     }
 
 

--- a/tests/Unit/Models/SessionTest.php
+++ b/tests/Unit/Models/SessionTest.php
@@ -76,6 +76,11 @@ class SessionTest extends TestCase
             'end_time' => $dateD1
         ]);
 
+        $sessionE = Session::factory()->create([
+            'start_time' => $dateD0,
+            'end_time' => $dateD1
+        ]);
+
         //A and B
         $this->assertFalse($sessionA->overlapsWith($sessionB));
         $this->assertFalse($sessionB->overlapsWith($sessionA));
@@ -99,5 +104,9 @@ class SessionTest extends TestCase
         //C and D
         $this->assertFalse($sessionC->overlapsWith($sessionD));
         $this->assertFalse($sessionD->overlapsWith($sessionC));
+
+        //D and E
+        $this->assertTrue($sessionD->overlapsWith($sessionE));
+        $this->assertTrue($sessionE->overlapsWith($sessionD));
     }
 }

--- a/tests/Unit/Models/SessionTest.php
+++ b/tests/Unit/Models/SessionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Models;
 
 use App\Models\Character;
 use App\Models\Session;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
@@ -36,5 +37,67 @@ class SessionTest extends TestCase
         $this->assertEquals(10, $sessionEmpty->open_seats);
         $this->assertEquals(5, $sessionHalf->open_seats);
         $this->assertEquals(0, $sessionFull->open_seats);
+    }
+
+    /**
+     * @test
+     */
+    public function overlaps_with_test()
+    {
+        $dateA0 = Carbon::now();
+        $dateA1 = Carbon::now()->addHours(4);
+
+        $dateB0 = Carbon::now()->addHours(5);
+        $dateB1 = Carbon::now()->addHours(9);
+
+        $dateC0 = Carbon::now()->addHours(6);
+        $dateC1 = Carbon::now()->addHours(10);
+
+        $dateD0 = Carbon::now()->addHours(11);
+        $dateD1 = Carbon::now()->addHours(15);
+
+        $sessionA = Session::factory()->create([
+            'start_time' => $dateA0,
+            'end_time' => $dateA1
+        ]);
+
+        $sessionB = Session::factory()->create([
+            'start_time' => $dateB0,
+            'end_time' => $dateB1
+        ]);
+
+        $sessionC = Session::factory()->create([
+            'start_time' => $dateC0,
+            'end_time' => $dateC1
+        ]);
+
+        $sessionD = Session::factory()->create([
+            'start_time' => $dateD0,
+            'end_time' => $dateD1
+        ]);
+
+        //A and B
+        $this->assertFalse($sessionA->overlapsWith($sessionB));
+        $this->assertFalse($sessionB->overlapsWith($sessionA));
+
+        //A and C
+        $this->assertFalse($sessionA->overlapsWith($sessionC));
+        $this->assertFalse($sessionC->overlapsWith($sessionA));
+
+        //A and D
+        $this->assertFalse($sessionA->overlapsWith($sessionD));
+        $this->assertFalse($sessionD->overlapsWith($sessionA));
+
+        //B and C
+        $this->assertTrue($sessionB->overlapsWith($sessionC));
+        $this->assertTrue($sessionC->overlapsWith($sessionB));
+
+        //B and D
+        $this->assertFalse($sessionB->overlapsWith($sessionD));
+        $this->assertFalse($sessionD->overlapsWith($sessionB));
+
+        //C and D
+        $this->assertFalse($sessionC->overlapsWith($sessionD));
+        $this->assertFalse($sessionD->overlapsWith($sessionC));
     }
 }


### PR DESCRIPTION
## Description
Closes #431
When a user attempts to register for an event session, the system will check if that session overlaps with any sessions that the user is registered for as a player or GM.