### PR TITLE
Entry create endpoint extension

### DIFF
--- a/app/Http/Controllers/DMEntryController.php
+++ b/app/Http/Controllers/DMEntryController.php
@@ -44,11 +44,19 @@ class DMEntryController extends Controller
         $search = $request->get("search");
         $characters = Character::where('user_id', Auth::user()->id)->get();
 
+        if ($campaignId = $request->get("campaign_id")) {
+            $campaign = Campaign::where('id', $campaignId);
+            $adventure = Campaign::where('id', $campaignId)->first()->adventure();
+        } else {
+            $adventure = Adventure::filtered($search);
+            $campaign = Campaign::filtered($search)->whereRelation('users', 'id', Auth::id());
+        }
+
         // not using compact to allow for partial reloads
         return Inertia::render('Entry/Create/DmEntryCreate', [
             'characters' => $characters,
-            'adventures' => fn () => Adventure::filtered($search)->get(['id', 'title', 'code']),
-            'campaigns' => fn () => Campaign::filtered($search)->whereRelation('users', 'id', Auth::id())->get(['id', 'title']),
+            'adventures' => fn () => $adventure->get(['id', 'title', 'code']),
+            'campaigns' => fn () => $campaign->get(['id', 'title']),
         ]);
     }
 }

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -50,10 +50,18 @@ class EntryController extends Controller
 
         $search = $data['search'] ?? "";
 
+        if ($campaignId = $request->get("campaign_id")) {
+            $campaign = Campaign::where('id', $campaignId);
+            $adventure = Campaign::where('id', $campaignId)->first()->adventure();
+        } else {
+            $adventure = Adventure::filtered($search);
+            $campaign = Campaign::filtered($search)->whereRelation('users', 'id', Auth::id());
+        }
+
         return Inertia::render('Character/Detail/Entry/Create/EntryCreate', [
             'character' => $character,
-            'campaigns' => fn () => Campaign::filtered($search)->whereRelation('users', 'id', Auth::id())->get(['id', 'title']),
-            'adventures' => fn () => Adventure::filtered($search)->get(['id', 'title', 'code']),
+            'campaigns' => fn () => $campaign->get(['id', 'title']),
+            'adventures' => fn () => $adventure->get(['id', 'title', 'code']),
             'gameMasters' => fn () => User::filtered($search)->get(['id', 'name']),
         ]);
     }

--- a/tests/Feature/Http/Controllers/DMEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/DMEntryControllerTest.php
@@ -69,6 +69,26 @@ class DMEntryControllerTest extends TestCase
     /**
      * @test
      */
+    public function create_displays_view_with_campaign_info()
+    {
+        $campaign = Campaign::factory()->create();
+
+        $response = $this->get(
+            route('dm-entry.create'),
+            ["campaign_id" => $campaign->id]
+        );
+
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component("Entry/Create/DmEntryCreate")
+                ->has('adventures')
+                ->has('campaigns')
+        );
+    }
+
+    /**
+     * @test
+     */
     public function storing_dm_entries_redirects()
     {
         $adventure = Adventure::factory()->create();

--- a/tests/Feature/Http/Controllers/DMEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/DMEntryControllerTest.php
@@ -73,10 +73,7 @@ class DMEntryControllerTest extends TestCase
     {
         $campaign = Campaign::factory()->create();
 
-        $response = $this->get(
-            route('dm-entry.create'),
-            ["campaign_id" => $campaign->id]
-        );
+        $response = $this->get(route('dm-entry.create', ["campaign_id" => $campaign->id]));
 
         $response->assertInertia(
             fn (Assert $page) => $page

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -136,6 +136,32 @@ class EntryControllerTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function create_displays_view_with_campaign_info()
+    {
+        $character = Character::factory()->create([
+            'user_id' => $this->user->id
+        ]);
+        $campaign = Campaign::factory()->has(Adventure::factory())->create();
+
+        $response = $this->get(route('entry.create', [
+            'character_id' => $character->id,
+            'campaign_id' => $campaign->id,
+            ]));
+
+        $response->assertOk();
+
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Character/Detail/Entry/Create/EntryCreate')
+                ->has('character')
+                ->has('campaigns')
+        );
+    }
+
+
 
     /**
      * @test


### PR DESCRIPTION
## Description
Closes #461
Adds a case to entry and DMentry controller create endpoints that allow them to accept campaign_id as part of the request and pass necessary info in the response to allow for the form to be partially autocompleted.

