### PR TITLE
Add Event filters and accessor to Model

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -135,8 +135,8 @@ class Entry extends Model
         return self::REWARD_CAMPAIGN;
     }
 
-    public function getDungeonMasterAttribute()
+    public function getDungeonMasterAttribute($dmAttribute)
     {
-        return $this->dungeonMaster()->first() ?? $this->attributes['dungeon_master'] ?? null;
+        return $this->dungeonMaster()->first() ?? $dmAttribute ?? null;
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -41,13 +41,14 @@ class Event extends Model
         'scheduled_dates',
         'total_seats',
         'seats_left',
-        'seats_taken'
+        'seats_taken',
+        'is_registered',
     ];
 
     protected $filterableFields = [
         'title',
         'description',
-        'location'
+        'location',
     ];
 
     public function entries()

--- a/tests/Unit/Models/EventTest.php
+++ b/tests/Unit/Models/EventTest.php
@@ -2,12 +2,15 @@
 
 namespace Tests\Unit\Models;
 
+use App\Models\Character;
 use App\Models\Entry;
 use App\Models\Event;
 use App\Models\League;
 use App\Models\Session;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Auth;
 use JMac\Testing\Traits\AdditionalAssertions;
 use Tests\TestCase;
 
@@ -45,8 +48,50 @@ class EventTest extends TestCase
      */
     public function can_belong_to_league()
     {
-        $event = Event::factory(1)->create()[0];
+        $event = Event::factory()->create();
 
         $this->assertCount(1, $event->league()->get());
+    }
+
+    /**
+     * @test
+     */
+    public function can_be_filtered_by_registered_user()
+    {
+        $characterFactory = Character::factory()->has(User::factory());
+        $sessionFactory = Session::factory()->has($characterFactory);
+        $event = Event::factory()->has($sessionFactory)->create();
+        // Create events that _shouldn't_ be returned
+        Event::factory(3)->has(Session::factory(5))->create();
+        $user = $event->sessions[0]->characters[0]->user;
+
+        $filtered = Event::whereRegistered($user->id)->get();
+        Auth::login($user);
+        $filteredViaLogin = Event::whereRegistered()->get();
+
+        $this->assertEquals($event->fresh(), $filtered[0]);
+        $this->assertEquals($filtered[0], $filteredViaLogin[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function is_registered_shows_when_authenticated_user_is_registered()
+    {
+        $characterFactory = Character::factory()->has(User::factory());
+        $sessionFactory = Session::factory()->has($characterFactory);
+        $event = Event::factory()->has($sessionFactory)->create();
+        // Create events that _shouldn't_ be returned
+        $otherEvents = Event::factory(3)->has(Session::factory(5))->create();
+        $user = $event->sessions[0]->characters[0]->user;
+        Auth::login($user);
+
+        $registeredEvent = $event->is_registered;
+        $nonRegisteredEvents = $otherEvents->map(fn ($e) => $e->is_registered);
+
+        $this->assertTrue($registeredEvent);
+        foreach ($nonRegisteredEvents as $registeredBool) {
+            $this->assertFalse($registeredBool);
+        }
     }
 }

--- a/tests/Unit/Models/EventTest.php
+++ b/tests/Unit/Models/EventTest.php
@@ -58,9 +58,7 @@ class EventTest extends TestCase
      */
     public function can_be_filtered_by_registered_user()
     {
-        $characterFactory = Character::factory()->has(User::factory());
-        $sessionFactory = Session::factory()->has($characterFactory);
-        $event = Event::factory()->has($sessionFactory)->create();
+        $event = $this->generateRegisteredEvent();
         // Create events that _shouldn't_ be returned
         Event::factory(3)->has(Session::factory(5))->create();
         $user = $event->sessions[0]->characters[0]->user;
@@ -78,9 +76,7 @@ class EventTest extends TestCase
      */
     public function is_registered_shows_when_authenticated_user_is_registered()
     {
-        $characterFactory = Character::factory()->has(User::factory());
-        $sessionFactory = Session::factory()->has($characterFactory);
-        $event = Event::factory()->has($sessionFactory)->create();
+        $event = $this->generateRegisteredEvent();
         // Create events that _shouldn't_ be returned
         $otherEvents = Event::factory(3)->has(Session::factory(5))->create();
         $user = $event->sessions[0]->characters[0]->user;
@@ -93,5 +89,17 @@ class EventTest extends TestCase
         foreach ($nonRegisteredEvents as $registeredBool) {
             $this->assertFalse($registeredBool);
         }
+    }
+
+    /**
+     * Utility function to extract
+     *
+     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model
+     */
+    private function generateRegisteredEvent()
+    {
+        $characterFactory = Character::factory()->has(User::factory());
+        $sessionFactory = Session::factory()->has($characterFactory);
+        return Event::factory()->has($sessionFactory)->create();
     }
 }


### PR DESCRIPTION
## Description
Closes #436 

Adds a query scope that allows events to be filtered by whether a particular user is registered to the event or not. 
Adds an accessor that determines if the logged in user is registered to the event

## How to test
1. In tinker, check the users registered to a particular event `App\Models\Sessions::where('event_id', "ID HERE")->with('characters')->get()`
2. Choose a `user_id` and try and filter Events by that id, `App\Models\Event::whereRegistered('USER_ID_HERE')->get()`
3. Notice that only the events that the above sessions belonged to were returned
4. Login as that user `Auth::loginUsingId("USER_ID")`
5. Check the accessor works as well `App\Models\Event::find("EVENT_ID)->is_registered`, should return true / false depending if the user is signed up for the event.