### PR TITLE
User deregistration from event session

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -87,6 +87,9 @@ Route::middleware(['auth', 'throttle'])->group(function () {
         'attach-entry-to-character' => 'character'
         ])->only('update');
 
+    Route::delete('/registration/{session}', [App\Http\Controllers\EventRegistrationController::class, 'destroy'])
+        ->name("event-registration.destroy");
+
     Route::resource('registration', App\Http\Controllers\EventRegistrationController::class)
         ->only('store');
 

--- a/tests/Feature/Http/Controllers/EventRegistrationControllerTest.php
+++ b/tests/Feature/Http/Controllers/EventRegistrationControllerTest.php
@@ -99,7 +99,6 @@ class EventRegistrationControllerTest extends TestCase
         $session = Session::factory()->create();
 
         $character->sessions()->attach($session);
-        $session->characters()->attach($character);
 
         $invalid_user = User::factory()->create();
 

--- a/tests/Feature/Http/Controllers/EventRegistrationControllerTest.php
+++ b/tests/Feature/Http/Controllers/EventRegistrationControllerTest.php
@@ -87,4 +87,34 @@ class EventRegistrationControllerTest extends TestCase
         $response->assertRedirect();
         $this->assertDatabaseCount('character_session', 1);
     }
+
+    /**
+     * @test
+     */
+    public function destroy_detaches_session_from_character()
+    {
+        $character = Character::factory()->create([
+            'user_id' => $this->user->id
+        ]);
+        $session = Session::factory()->create();
+
+        $character->sessions()->attach($session);
+        $session->characters()->attach($character);
+
+        $invalid_user = User::factory()->create();
+
+        $response_invalid = $this->actingAs($invalid_user)->delete(route('event-registration.destroy', $session), [
+            'character_id' => $character->id
+        ]);
+
+        $response_invalid->assertRedirect();
+        $response_invalid->assertSessionHasErrors();
+
+        $response = $this->actingAs($this->user)->delete(route('event-registration.destroy', $session), [
+            'character_id' => $character->id
+        ]);
+
+        $response->assertRedirect();
+        $this->assertNotContains($session, $character->sessions);
+    }
 }


### PR DESCRIPTION
### Description
Closes #438 
Implementation of destroy function in EventRegistrationController to allow user to deregister an owned character from a session. 

### To Test
- Create a session and a character
- Register character for session using `$character->sessions()->attach($session)` ...(could also make a more formal store request passing the event_id, session_id and character_id instead)
- Make call to destroy function passing it the session object as a parameter and the character's id in the request
- Verify if the session was removed from the character's sessions() collection
