### PR TITLE
Remove last url dependency between tests

### DIFF
--- a/cypress/integration/Event Management/admin_event_crud.js
+++ b/cypress/integration/Event Management/admin_event_crud.js
@@ -18,15 +18,10 @@ describe('Admin Event CRUD Test Suite', () => {
         cy.wait('@last_url')
     })
 
-    afterEach(() => {
-        cy.url().then((urlString) => {
-            last_url = urlString
-        })
-    })
-
     it('Event Index', () => {
         cy.contains('Events').click()
         cy.get('table[id="crudTable"]')
+        last_url = `${Cypress.config('baseUrl')}/admin/event/`
     })
 
     it('Event Creation', () => {


### PR DESCRIPTION
Closes #470

## Description
Removes last url dependency between tests, so that each test start on the right page.