### PR TITLE
Adventures League Import Response Bug Fix

### DIFF
--- a/app/Exceptions/ImportException.php
+++ b/app/Exceptions/ImportException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class ImportException extends Exception
+{
+    public function __construct($message = "Character could not be imported.", $code = 400, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Exceptions/ImportException.php
+++ b/app/Exceptions/ImportException.php
@@ -6,8 +6,8 @@ use Exception;
 
 class ImportException extends Exception
 {
-    public function __construct($message = "Character could not be imported.", $code = 400, Throwable $previous = null)
+    public function __construct($message = "Character could not be imported.", $code = 400)
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, $code);
     }
 }

--- a/app/Http/Controllers/AdventuresLeagueImportController.php
+++ b/app/Http/Controllers/AdventuresLeagueImportController.php
@@ -28,13 +28,12 @@ class AdventuresLeagueImportController extends Controller
     public function store(Request $request)
     {
         if ($request->hasFile('logs')) {
-            $character = AdventuresLeague::getCharacter($request->file('logs')->getRealPath());
-            if (is_null($character)) {
-                return back()->withException(new \Exception("Adventure's League Log File Error: Export File Format Changed", 400));
+            try {
+                $character = AdventuresLeague::getCharacter($request->file('logs')->getRealPath());
+            } catch (\Exception $e) {
+                return back()->withException($e);
             }
-
             $character->save();
-
             return redirect(route('character.show', ['character' => $character->refresh()->load('entries')]));
         } else {
             return back()->withException(new \Exception("Adventure's League Log File Error", 400));

--- a/app/Http/Controllers/AdventuresLeagueImportController.php
+++ b/app/Http/Controllers/AdventuresLeagueImportController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\ImportException;
 use App\Facades\AdventuresLeague;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -30,7 +31,7 @@ class AdventuresLeagueImportController extends Controller
         if ($request->hasFile('logs')) {
             try {
                 $character = AdventuresLeague::getCharacter($request->file('logs')->getRealPath());
-            } catch (\Exception $e) {
+            } catch (ImportException $e) {
                 return back()->withException($e);
             }
             $character->save();

--- a/app/Http/Controllers/AdventuresLeagueImportController.php
+++ b/app/Http/Controllers/AdventuresLeagueImportController.php
@@ -30,20 +30,14 @@ class AdventuresLeagueImportController extends Controller
         if ($request->hasFile('logs')) {
             $character = AdventuresLeague::getCharacter($request->file('logs')->getRealPath());
             if (is_null($character)) {
-                return response([
-                    'success' => false,
-                    'errors' => "Adventure's League Log File Error: Export File Format Changed",
-                ], 400);
+                return back()->withException(new \Exception("Adventure's League Log File Error: Export File Format Changed", 400));
             }
 
             $character->save();
 
             return redirect(route('character.show', ['character' => $character->refresh()->load('entries')]));
         } else {
-            return response([
-                'success' => false,
-                'errors' => "Adventure's League Log File Error"
-            ], 400);
+            return back()->withException(new \Exception("Adventure's League Log File Error", 400));
         }
     }
 }

--- a/app/Services/AdventuresLeagueAdapter.php
+++ b/app/Services/AdventuresLeagueAdapter.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Exceptions\ImportException;
 use App\Models\Character;
 use App\Models\Entry;
 use App\Models\Item;
@@ -38,7 +39,7 @@ class AdventuresLeagueAdapter
 
         // Check if export format is what we expect
         if ($data[0] != "name,race,class_and_levels,faction,background,lifestyle,portrait_url,publicly_visible") {
-            throw new \Exception("Adventure's League Log File Error: Export File Format Changed", 400);
+            throw new ImportException("Adventure's League Log File Error: Export File Format Changed", 400);
         }
 
         // Separate lines into cells

--- a/app/Services/AdventuresLeagueAdapter.php
+++ b/app/Services/AdventuresLeagueAdapter.php
@@ -38,7 +38,7 @@ class AdventuresLeagueAdapter
 
         // Check if export format is what we expect
         if ($data[0] != "name,race,class_and_levels,faction,background,lifestyle,portrait_url,publicly_visible") {
-            return null;
+            throw new \Exception("Adventure's League Log File Error: Export File Format Changed", 400);
         }
 
         // Separate lines into cells

--- a/tests/Feature/Http/Controllers/AdventuresLeagueImportControllerTest.php
+++ b/tests/Feature/Http/Controllers/AdventuresLeagueImportControllerTest.php
@@ -105,7 +105,11 @@ class AdventuresLeagueImportControllerTest extends TestCase
         $user = User::factory()->create();
         $csv = new UploadedFile(database_path('mocks/grod-bad.csv'), "grod-bad.csv");
         $response = $this->actingAs($user)->post('/adventures-league-import', ['logs' => $csv]);
-        $response->assertStatus(400);
+
+        $this->assertNotNull($response->exception);
+        $this->assertEquals("Adventure's League Log File Error: Export File Format Changed", $response->exception->getMessage());
+        $this->assertEquals(400, $response->exception->getCode());
+        $response->assertRedirect();
     }
 
     /**
@@ -115,6 +119,9 @@ class AdventuresLeagueImportControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $response = $this->actingAs($user)->post('/adventures-league-import');
-        $response->assertStatus(400);
+        $this->assertNotNull($response->exception);
+        $this->assertEquals("Adventure's League Log File Error", $response->exception->getMessage());
+        $this->assertEquals(400, $response->exception->getCode());
+        $response->assertRedirect();
     }
 }

--- a/tests/Unit/Adapters/AdventuresLeagueTest.php
+++ b/tests/Unit/Adapters/AdventuresLeagueTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Adapters;
 
+use App\Exceptions\ImportException;
 use App\Facades\AdventuresLeague;
 use App\Facades\Beyond;
 use App\Models\User;
@@ -48,8 +49,8 @@ class AdventuresLeagueTest extends TestCase
      */
     public function check_character_hydration_fails_if_bad_file()
     {
+        $this->expectException(ImportException::class);
         $character = AdventuresLeague::getCharacter(database_path('mocks/grod-bad.csv'));
-
         $this->assertNull($character);
     }
 }


### PR DESCRIPTION
## Description
Closes #424
Previously the adventures league importer and the associated controller were not handling file exceptions correctly.
When the user uploaded a bad file, or a missing file, they were shown a verbose php error. Instead, the controller now redirects them back to the character import page.

## Test
Log in as a user
Navigate to the character import page
Attempt to import from a bad file (any file that is not a valid csv is fine, for example an image of your cat)
Check that the user is redirected back to the same page
Attempt to import a valid file (found in the database/mocks directory of the project)
Check the you are redirected to the created character's page