### PR TITLE
Fix campaign character duplication bug

### DIFF
--- a/app/Http/Controllers/CampaignRegistrationController.php
+++ b/app/Http/Controllers/CampaignRegistrationController.php
@@ -44,16 +44,23 @@ class CampaignRegistrationController extends Controller
         $campaign = Campaign::where('code', $data['code'])->firstOrFail();
 
         if ($request->has('character_id')) {
-            $user->campaigns()->attach($campaign, ['is_dm' => false, 'is_owner' => false]);
+            $user->campaigns()->syncWithoutDetaching([$campaign->id => ['is_dm' => false, 'is_owner' => false]]);
             $character = Character::findOrFail($data['character_id']);
-            $character->campaigns()->attach($campaign);
+            $character->campaigns()->syncWithoutDetaching($campaign);
         } else {
-            $user->campaigns()->attach($campaign, ['is_dm' => true, 'is_owner' => false]);
+            $user->campaigns()->syncWithoutDetaching([$campaign->id => ['is_dm' => true, 'is_owner' => false]]);
         }
 
         return redirect()->route('campaign.index');
     }
 
+    /**
+     * De-register a user and their characters from a campaign
+     *
+     * @param Request $request
+     * @param Campaign $campaignRegistration
+     * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
+     */
     public function destroy(Request $request, Campaign $campaignRegistration)
     {
         $data = $request->validate([

--- a/database/migrations/2022_03_10_020408_add_unique_constraint_to_campaign_character_table.php
+++ b/database/migrations/2022_03_10_020408_add_unique_constraint_to_campaign_character_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUniqueConstraintToCampaignCharacterTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('campaign_character', function (Blueprint $table) {
+            $table->unique(['character_id', 'campaign_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('campaign_character', function (Blueprint $table) {
+            $table->dropUnique(['character_id', 'campaign_id']);
+        });
+    }
+}


### PR DESCRIPTION
## Description
Closes #486 

Prevents a user from registering the same character to the same campaign more than once. 
Additionally prevents a user from being registered to a campaign more than once. 