### PR TITLE
Fix redirects for campaign registration

### DIFF
--- a/app/Http/Controllers/CampaignRegistrationController.php
+++ b/app/Http/Controllers/CampaignRegistrationController.php
@@ -12,7 +12,7 @@ class CampaignRegistrationController extends Controller
 {
     /**
      * @param \Illuminate\Http\Request $request
-     * @return \Inertia\Response
+     * @return \Illuminate\Http\RedirectResponse|\Inertia\Response
      */
     public function create(Request $request)
     {
@@ -23,6 +23,10 @@ class CampaignRegistrationController extends Controller
         ])['code'] ?? null;
 
         $campaign = Campaign::with('characters', 'users')->where('code', $code)->first();
+
+        if (!$campaign) {
+            return redirect()->back()->withErrors(['error' => "The provided campaign code is incorrect."]);
+        }
 
         return Inertia::render('Campaign/Registration/Create/CampaignRegistrationCreate', compact('characters', 'campaign', 'code'));
     }
@@ -43,7 +47,7 @@ class CampaignRegistrationController extends Controller
         $user = Auth::user();
         $campaign = Campaign::where('code', $data['code'])->firstOrFail();
 
-        if ($request->has('character_id')) {
+        if (!empty($data['character_id'])) {
             $user->campaigns()->syncWithoutDetaching([$campaign->id => ['is_dm' => false, 'is_owner' => false]]);
             $character = Character::findOrFail($data['character_id']);
             $character->campaigns()->syncWithoutDetaching($campaign);

--- a/tests/Feature/Http/Controllers/CampaignRegistrationControllerTest.php
+++ b/tests/Feature/Http/Controllers/CampaignRegistrationControllerTest.php
@@ -49,6 +49,21 @@ class CampaignRegistrationControllerTest extends TestCase
     /**
      * @test
      */
+    public function create_redirects_with_incorrect_code()
+    {
+        $inputData = [
+            'code' => 'invalid code'
+        ];
+
+        $response = $this->get(route('campaign-registration.create', $inputData));
+
+        $response->assertRedirect();
+        $response->assertSessionHasErrors('error');
+    }
+
+    /**
+     * @test
+     */
     public function store_registers_a_character_and_user_for_a_campaign()
     {
         $character = Character::factory()->create([


### PR DESCRIPTION
## Description
Closes #492 

Adjusts redirects when joining or creating campaigns to redirect to the appropriate place and return errors where appropriate