### PR TITLE
GM Entry Creation Bug Fix

### DIFF
--- a/app/Exceptions/GMEntryException.php
+++ b/app/Exceptions/GMEntryException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class GMEntryException extends Exception
+{
+    public function __construct($message = "GM Entry Exception", $code = 400)
+    {
+        parent::__construct($message, $code);
+    }
+}

--- a/app/Http/Controllers/DMEntryController.php
+++ b/app/Http/Controllers/DMEntryController.php
@@ -49,7 +49,12 @@ class DMEntryController extends Controller
             $adventure = Campaign::where('id', $campaignId)->first()->adventure();
         } else {
             $adventure = Adventure::filtered($search);
-            $campaign = Campaign::filtered($search)->whereRelation('users', 'id', Auth::id());
+            $campaign = Campaign::filtered($search)
+                ->whereHas('users', function ($query) {
+                    return $query
+                        ->where('id', Auth::id())
+                        ->where('is_dm', true);
+                });
         }
 
         // not using compact to allow for partial reloads

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -94,9 +94,9 @@ class EntryController extends Controller
 
         list($entryData, $itemData) = $this->chooseReward($entryData, $itemData);
 
-        if ($entryData['type'] === Entry::TYPE_DM && !empty($entryData['campaign']['id'])) {
-            $campaign = Campaign::find($entryData['campaign']['id']);
-            $campaignGmIds = $campaign->users()->wherePivot('is_dm', true)->pluck('id')->get();
+        if ($entryData['type'] === Entry::TYPE_DM && !empty($entryData['campaign_id'])) {
+            $campaign = Campaign::find($entryData['campaign_id']);
+            $campaignGmIds = $campaign->users()->wherePivot('is_dm', true)->pluck('id');
             if (!$campaignGmIds->contains(Auth::id())) {
                 $exception = new GMEntryException("GM Entry Exception: Cannot create a GM entry on a campaign in which user is not a GM.");
                 return redirect()->back()->withException($exception);

--- a/app/Http/Controllers/EntryController.php
+++ b/app/Http/Controllers/EntryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Actions\CreateEntryItems;
 use App\Actions\CreateAndAttachRating;
+use App\Exceptions\GMEntryException;
 use App\Http\Requests\EntryStoreRequest;
 use App\Http\Requests\EntryUpdateRequest;
 use App\Models\Campaign;
@@ -93,7 +94,14 @@ class EntryController extends Controller
 
         list($entryData, $itemData) = $this->chooseReward($entryData, $itemData);
 
-        if (!empty($entryData['dungeon_master']['id']) && $entryData['type'] !== Entry::TYPE_DM) {
+        if ($entryData['type'] === Entry::TYPE_DM && !empty($entryData['campaign']['id'])) {
+            $campaign = Campaign::find($entryData['campaign']['id']);
+            $campaignGmIds = $campaign->users()->wherePivot('is_dm', true)->pluck('id')->get();
+            if (!$campaignGmIds->contains(Auth::id())) {
+                $exception = new GMEntryException("GM Entry Exception: Cannot create a GM entry on a campaign in which user is not a GM.");
+                return redirect()->back()->withException($exception);
+            }
+        } elseif (!empty($entryData['dungeon_master']['id']) && $entryData['type'] !== Entry::TYPE_DM) {
             $entryData['dungeon_master_id'] = $entryData['dungeon_master']['id'];
             $entryData->forget('dungeon_master');
         } else {

--- a/tests/Feature/Http/Controllers/DMEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/DMEntryControllerTest.php
@@ -90,6 +90,7 @@ class DMEntryControllerTest extends TestCase
     {
         $adventure = Adventure::factory()->create();
         $campaign = Campaign::factory()->create();
+        $campaign->users()->attach($this->user, ['is_dm' => true]);
         $event = Event::factory()->create();
         $date_played = $this->faker->dateTime();
         $location = $this->faker->word;

--- a/tests/Feature/Http/Controllers/EntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/EntryControllerTest.php
@@ -385,7 +385,6 @@ class EntryControllerTest extends TestCase
         $response_advancement = $this->actingAs($this->user)->post(route('entry.store'), [
             'user_id' => $this->user->id,
             'adventure' => ['id' => $adventure->id],
-            'campaign_id' => $campaign->id,
             'character_id' => $character_adv->id,
             'event_id' => $event->id,
             'dungeon_master_id' => $dungeon_master_user->id,
@@ -402,7 +401,6 @@ class EntryControllerTest extends TestCase
         $response_MI = $this->actingAs($this->user)->post(route('entry.store'), [
             'user_id' => $this->user->id,
             'adventure' => ['id' => $adventure->id],
-            'campaign_id' => $campaign->id,
             'character_id' => $character_MI->id,
             'event_id' => $event->id,
             'dungeon_master_id' => $dungeon_master_user->id,
@@ -420,7 +418,6 @@ class EntryControllerTest extends TestCase
         $response_CR = $this->actingAs($this->user)->post(route('entry.store'), [
             'user_id' => $this->user->id,
             'adventure' => ['id' => $adventure->id],
-            'campaign_id' => $campaign->id,
             'character_id' => $character_CR->id,
             'event_id' => $event->id,
             'dungeon_master_id' => $dungeon_master_user->id,
@@ -651,6 +648,7 @@ class EntryControllerTest extends TestCase
 
         $adventure = Adventure::factory()->create();
         $campaign = Campaign::factory()->create();
+        $campaign->users()->attach($this->user, ['is_dm' => true]);
         $event = Event::factory()->create();
         $dungeon_master_user = User::factory()->create();
         $dungeon_master = $this->faker->word;
@@ -945,5 +943,40 @@ class EntryControllerTest extends TestCase
         $this->assertCount(2, $entry->items);
         $this->assertDatabaseHas('items', $itemData[0]);
         $this->assertDatabaseHas('items', $itemData[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function store_gm_entry_on_campaign_as_player_throws_exception()
+    {
+        $adventure = Adventure::factory()->create();
+        $campaign = Campaign::factory()->create();
+        $date_played = $this->faker->dateTime();
+        $type = Entry::TYPE_DM;
+
+        $campaign->users()->attach($this->user, ['is_dm' => false]);
+
+        $response = $this->actingAs($this->user)->post(route('entry.store'), [
+            'user_id' => $this->user->id,
+            'adventure' => ['id' => $adventure->id],
+            'campaign_id' => $campaign->id,
+            'date_played' => $date_played,
+            'type' => $type,
+            'choice' => 'advancement',
+        ]);
+
+        $createdEntries = Entry::where([
+            'user_id' => $this->user->id,
+            'campaign_id' => $campaign->id,
+            'date_played' => $date_played,
+            'type' => $type,
+        ])->get();
+
+        $this->assertEmpty($createdEntries);
+        $this->assertNotNull($response->exception);
+        $this->assertEquals("GM Entry Exception: Cannot create a GM entry on a campaign in which user is not a GM.", $response->exception->getMessage());
+        $this->assertEquals(400, $response->exception->getCode());
+        $response->assertRedirect();
     }
 }


### PR DESCRIPTION
## Description
Closes #519 
Prevents users from creating GM entries for campaigns in which they are not a GM.

## Changes
Changes the campaigns returned in the GMEntry create endpoint
Also changes the GMEntry auth