### PR TITLE
Fix rating cascade delete error on campaign delete

### DIFF
--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\Traits\Filterable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
 
 class Campaign extends Model
@@ -12,6 +13,7 @@ class Campaign extends Model
     use \Backpack\CRUD\app\Models\Traits\CrudTrait;
     use HasFactory;
     use Filterable;
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/database/migrations/2022_03_25_001339_add_soft_deletes_to_campaigns_table.php
+++ b/database/migrations/2022_03_25_001339_add_soft_deletes_to_campaigns_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddCodeToCampaignsTable extends Migration
+class AddSoftDeletesToCampaignsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -14,7 +14,7 @@ class AddCodeToCampaignsTable extends Migration
     public function up()
     {
         Schema::table('campaigns', function (Blueprint $table) {
-            $table->string('code')->nullable()->after('title');
+            $table->softDeletes();
         });
     }
 
@@ -26,7 +26,7 @@ class AddCodeToCampaignsTable extends Migration
     public function down()
     {
         Schema::table('campaigns', function (Blueprint $table) {
-            $table->dropColumn('code');
+            $table->dropSoftDeletes();
         });
     }
 }

--- a/tests/Feature/Http/Controllers/CampaignControllerTest.php
+++ b/tests/Feature/Http/Controllers/CampaignControllerTest.php
@@ -253,7 +253,7 @@ class CampaignControllerTest extends TestCase
         $response = $this->delete(route('campaign.destroy', $campaign));
 
         $response->assertRedirect(route('campaign.index'));
-        $this->assertDeleted($campaign);
+        $this->assertSoftDeleted($campaign);
     }
 
     /**


### PR DESCRIPTION
## Description
Closes #512 

Adds soft deletes to campaigns to allow for easily deleting / archiving of campaigns without violating cascade constraints.

This solution avoids messy n+1 detach logic that would have to be added to the destroy logic in the controller. 

## How to test
Simply attempt to delete a campaign which has entries / ratings attached to it.