### PR TITLE
Update Reward accessor to return Null

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -118,12 +118,8 @@ class Entry extends Model
 
     public function getRewardAttribute()
     {
-        if ($this->type != self::TYPE_DM) {
+        if ($this->type != self::TYPE_DM || is_null($this->character_id)) {
             return null;
-        }
-
-        if (is_null($this->character_id)) {
-            return "-";
         }
 
         if ($this->levels >= 1) {


### PR DESCRIPTION
## Description
Closes #446 

Minor formatting change, update the computed reward field to return null and instead depend on FE to format / display a specific text.
