### PR TITLE
Fix DM entry display bug on campaign details

### DIFF
--- a/resources/js/Components/Detail/CampaignDetail/CampaignDetailBox.tsx
+++ b/resources/js/Components/Detail/CampaignDetail/CampaignDetailBox.tsx
@@ -50,12 +50,12 @@ const CampaignDetailBox = ({
                         <StyledTypography>{t('campaignDetail.adventure')}</StyledTypography>
                         <Typography>{campaign.adventure.title}</Typography>
                     </Grid>
-                    {userCharacter && (
+                    {campaign.entries && (
                         <Grid item xs={12}>
                             <StyledTypography>
                                 {t('campaignDetail.sessions-played')}
                             </StyledTypography>
-                            <Typography>{userCharacter.entries.length}</Typography>
+                            <Typography>{campaign.entries.length}</Typography>
                         </Grid>
                     )}
                     <Grid item xs={12}>

--- a/resources/js/Pages/Campaign/Detail/CampaignDetail.tsx
+++ b/resources/js/Pages/Campaign/Detail/CampaignDetail.tsx
@@ -82,9 +82,9 @@ const CampaignDetail = ({
                 userCharacter={userCharacter}
                 setIsEditDrawerOpen={setIsEditCampaignDrawerOpen}
             />
-            {userCharacter && (
+            {campaign.entries && (
                 <EntryTable
-                    data={userCharacter.entries}
+                    data={campaign.entries}
                     setEditEntryId={setEditId}
                     setEditEntryData={setEditData}
                     setIsEditDrawerOpen={setIsEditDrawerOpen}

--- a/resources/js/Types/campaign-data.ts
+++ b/resources/js/Types/campaign-data.ts
@@ -1,4 +1,5 @@
 import {CharacterData} from 'Types/character-data'
+import {EntriesData} from 'Types/entries-data'
 
 export type CampaignData = {
     id: number
@@ -10,5 +11,6 @@ export type CampaignData = {
     code: string
     character_id: number
     characters: CharacterData[]
+    entries: EntriesData[]
     is_owner: boolean
 }


### PR DESCRIPTION
## Description
Closes #501 

Adjusts the query returning entries for a given campaign to instead load entries via the campaign model rather than the character model. Update the front end to reflect this change as well. Add missing types for entry on campaign as well.

## How to Test
1. Create or join a campaign as the DM
2. Create a new entry
3. Observe that the entry now shows in the entry table on the campaign details page
4. Observe that you can delete the entry which causes it to disappear. 
5. Observe that the entry table still shows up for other player characters in the campaign.