### PR TITLE
Cypress test for Campaign Entry Creation

### DIFF
--- a/cypress/integration/Campaign Management/campaign_enrollment_and_entry_creation.js
+++ b/cypress/integration/Campaign Management/campaign_enrollment_and_entry_creation.js
@@ -1,8 +1,10 @@
-describe('Campaign Enrollment Test Suite', () => {
+describe('Campaign Enrollment and Entry Creation Test Suite', () => {
     let campaign_title
     let code
     let campaign_exploration_link
     let campaign_exploration_id
+    const levelup = 2
+
     before(() => {
         cy.refreshDatabase()
         cy.seed('FastSeeder')
@@ -51,6 +53,31 @@ describe('Campaign Enrollment Test Suite', () => {
             })
     })
 
+    it('Create Campaign Entry', () => {
+        cy.login({id: 2})
+
+        cy.intercept('GET', campaign_exploration_link).as('campaign_detail')
+        cy.visit(campaign_exploration_link)
+        cy.wait('@campaign_detail')
+
+        cy.contains('button', 'Entry')
+            .click()
+            .then(() => {
+                cy.get('#levels').clear().type(levelup)
+                cy.contains('button', 'Continue').click()
+                cy.contains('button', 'Create').click()
+                cy.url().should('include', campaign_exploration_id)
+            })
+            .then(() => {
+                cy.login({id: 1})
+
+                cy.visit(campaign_exploration_link)
+                cy.wait('@campaign_detail')
+                cy.contains('Entries')
+                cy.get('[data-cy="levels"]').contains(levelup)
+            })
+    })
+
     it('Kick User from Campaign', () => {
         cy.login({id: 1})
 
@@ -62,7 +89,7 @@ describe('Campaign Enrollment Test Suite', () => {
         cy.wait('@getPublicCampaign')
 
         cy.contains('button', 'Kick').click()
-        cy.get('[type="checkbox"]').first().check()
+        cy.get('[data-cy="campaign_member"]>input').first().check()
 
         cy.contains('button', 'Submit').click()
         cy.get('[data-cy="campaign_invite_code"]')

--- a/resources/js/Components/Modal/CampaignKickModal.tsx
+++ b/resources/js/Components/Modal/CampaignKickModal.tsx
@@ -39,6 +39,7 @@ const CampaignKickModal = ({open, onClose, campaign}: CampaignKickModalPropType)
                                     <Checkbox
                                         id={character.id}
                                         checked={data.user_id.includes(character.user_id)}
+                                        data-cy='campaign_member'
                                         onChange={() => {
                                             if (data.user_id.includes(character.user_id)) {
                                                 const newUserIds = data.user_id.filter(

--- a/resources/js/Components/Table/EntryTable/EntryTable.tsx
+++ b/resources/js/Components/Table/EntryTable/EntryTable.tsx
@@ -70,6 +70,7 @@ const EntryTable = ({
         {
             property: 'levels',
             title: t('tableColumn.level'),
+            render: (value: any) => <Typography data-cy='levels'>{value}</Typography>,
         },
         {
             property: 'gp',


### PR DESCRIPTION
### Description
Closes #445 

Cypress test for Campaign Entry Creation
Creates entry from character enrolled in campaign and checks from another user's perspective if entry appears in CampaignDetail.

This test was added to the original campaign_enrollment.js test suite to avoid duplicating the joining portion at the start. 
