### PR TITLE
perf: #539 call cy.login instead of using UI to log into default test…

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,18 +1,19 @@
 Cypress.Commands.add('seederLogin', () => {
-    const testuser_email = 'default@test.com'
-    const testuser_password = 'password'
-    const testusername = 'Test account'
-    cy.intercept('GET', '/').as('landingpage')
-    cy.intercept('POST', '/login').as('login')
-    cy.visit('/')
-    cy.wait('@landingpage')
-    cy.get('[data-testid="PersonIcon"]').click()
-    cy.contains('button', 'LOGIN').click()
-    cy.get('#email').type(testuser_email)
-    cy.get('#password').clear().type(testuser_password)
-    cy.get('button[type="submit"]').click()
-    cy.wait('@login')
-    cy.get('[data-cy="user"]').should('contain', testusername)
+    // const testuser_email = 'default@test.com'
+    // const testuser_password = 'password'
+    // const testusername = 'Test account'
+    // cy.intercept('GET', '/').as('landingpage')
+    // cy.intercept('POST', '/login').as('login')
+    // cy.visit('/')
+    // cy.wait('@landingpage')
+    // cy.get('[data-testid="PersonIcon"]').click()
+    // cy.contains('button', 'LOGIN').click()
+    // cy.get('#email').type(testuser_email)
+    // cy.get('#password').clear().type(testuser_password)
+    // cy.get('button[type="submit"]').click()
+    // cy.wait('@login')
+    // cy.get('[data-cy="user"]').should('contain', testusername)
+    cy.login({id: 1})
 })
 
 Cypress.Commands.add('seederLoginLeagueAdmin', () => {


### PR DESCRIPTION
Closes #539

## Description
Use `cy.login({id: 1})` call to log into the default user instead of using the UI.