### PR TITLE
Hotfix: add session seats to backpack

### DIFF
--- a/app/Http/Controllers/Admin/SessionCrudController.php
+++ b/app/Http/Controllers/Admin/SessionCrudController.php
@@ -61,6 +61,7 @@ class SessionCrudController extends CrudController
         CRUD::column('adventure_id');
         CRUD::column('dungeonMaster');
         CRUD::column('table');
+        CRUD::column('seats');
         CRUD::column('start_time');
         CRUD::column('end_time');
     }
@@ -109,6 +110,8 @@ class SessionCrudController extends CrudController
         CRUD::field('adventure_id');
         CRUD::field('dungeonMaster');
         CRUD::field('table');
+        CRUD::field('seats')->default(8);
+        CRUD::field('language')->type('enum');
         CRUD::field('start_time');
         CRUD::field('end_time');
     }

--- a/database/factories/CharacterFactory.php
+++ b/database/factories/CharacterFactory.php
@@ -23,11 +23,38 @@ class CharacterFactory extends Factory
      */
     public function definition()
     {
+        $races = [
+            "Dwarf",
+            "Elf",
+            "Halfling",
+            "Human",
+            "Dragonborn",
+            "Gnome",
+            "Half-Elf",
+            "Half-Orc",
+            "Tiefling",
+        ];
+
+        $classes = [
+            "Barbarian",
+            "Bard",
+            "Cleric",
+            "Druid",
+            "Fighter",
+            "Monk",
+            "Paladin",
+            "Ranger",
+            "Rogue",
+            "Sorcerer",
+            "Warlock",
+            "Wizard",
+        ];
+
         return [
             'user_id' => User::factory(),
             'name' => $this->faker->name(),
-            'race' => $this->faker->word(),
-            'class' => $this->faker->word(),
+            'race' => $this->faker->randomElement($races),
+            'class' => $this->faker->randomElement($classes),
             'level' => $this->faker->numberBetween(1, 20),
             'faction' => $this->faker->randomElement(array_values(Character::FACTIONS)),
             'downtime' => $this->faker->numberBetween(0, 1000),

--- a/database/factories/EntryFactory.php
+++ b/database/factories/EntryFactory.php
@@ -35,7 +35,7 @@ class EntryFactory extends Factory
             'event_id' => Event::factory(),
             'dungeon_master_id' => User::factory(),
             'dungeon_master' => $this->faker->word(),
-            'date_played' => $this->faker->dateTime(),
+            'date_played' => $this->faker->dateTimeBetween("-5 years"),
             'location' => $this->faker->word(),
             'type' => $this->faker->word(),
             'length' => $this->faker->numberBetween(0, 10),

--- a/database/factories/SessionFactory.php
+++ b/database/factories/SessionFactory.php
@@ -26,7 +26,7 @@ class SessionFactory extends Factory
      */
     public function definition()
     {
-        $startTime = $this->faker->dateTime();
+        $startTime = $this->faker->dateTimeBetween("-5 Years");
 
         return [
             'event_id' => Event::factory(),
@@ -35,7 +35,7 @@ class SessionFactory extends Factory
             'table' => $this->faker->randomDigit()+1,
             'seats' => $this->faker->numberBetween(2, 8),
             'start_time' => $startTime,
-            'end_time' => $this->faker->dateTimeBetween($startTime, $endDate = 'now'),
+            'end_time' => $this->faker->dateTimeBetween($startTime),
             'language' => $this->faker->randomElement(["FR","EN"]),
         ];
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -174,11 +174,12 @@ class DatabaseSeeder extends Seeder
         // Each event will have 3 sessions being run at them
         foreach ($events as $event) {
             $seats = rand(2, 7);
+            $dm = $dm->shuffle();
             $sessions = Session::factory(3)
                 ->has(Character::factory($seats - rand(0, 2)))
+                ->sequence(fn ($sequence) => ['dungeon_master_id' => $dm[$sequence->index]])
                 ->create([
                     'event_id' => $event->id,
-                    'dungeon_master_id' => $dm->random()->id,
                     'seats' => $seats
                 ])->merge($sessions);
         }


### PR DESCRIPTION
## Description
Adds the missing `seats` column to laravel backpack. This allows Site and league admins to set the available amount of characters that can register for a session. Also adds the missing `language` field

Also adds some more realistic values to factories, so that characters generated now have real races and classes

Hotfix as this is a last minute bug that came up.

Adds These fields:  
![image](https://user-images.githubusercontent.com/9440691/161443051-fee4333f-7a40-4628-a2dc-32843d4ca46f.png)
